### PR TITLE
Allow whitespace in the 'Content-Length' header.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1264,6 +1264,7 @@ size_t http_parser_execute (http_parser *parser,
             break;
 
           case h_content_length:
+            if (ch == ' ') break;
             if (ch < '0' || ch > '9') goto error;
             parser->content_length *= 10;
             parser->content_length += ch - '0';


### PR DESCRIPTION
See:

http://groups.google.com/group/nodejs/browse_thread/thread/5c1b72df183d6fe4
and:
http://github.com/ry/http-parser/issues#issue/10

for related info. This fix simply allows space characters in the `Content-Type` header, which I and apparently others have encountered from remote servers which we have no control over.
