### PR TITLE
lowercasing in header after check for CR LF

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1186,8 +1186,6 @@ size_t http_parser_execute (http_parser *parser,
         state = s_header_value;
         index = 0;
 
-        c = LOWER(ch);
-
         if (ch == CR) {
           CALLBACK(header_value);
           header_state = h_general;
@@ -1200,6 +1198,8 @@ size_t http_parser_execute (http_parser *parser,
           state = s_header_field_start;
           break;
         }
+
+        c = LOWER(ch);
 
         switch (header_state) {
           case h_upgrade:
@@ -1242,7 +1242,6 @@ size_t http_parser_execute (http_parser *parser,
 
       case s_header_value:
       {
-        c = LOWER(ch);
 
         if (ch == CR) {
           CALLBACK(header_value);
@@ -1254,6 +1253,8 @@ size_t http_parser_execute (http_parser *parser,
           CALLBACK(header_value);
           goto header_almost_done;
         }
+
+        c = LOWER(ch);
 
         switch (header_state) {
           case h_general:


### PR DESCRIPTION
tiny change:

c = LOWER(ch) is called unnecessarily in case ch is CR or LF.

Another thing I noticed, but don't understand is in the `tokens` lookup table: not all separators are mapped, e.g. '}', '/' and " are mapped, but all the other ones aren't. I assume this is intentional, but it seems irregular & contradicts the comments, so I thought I'd point it out.
