### PR TITLE
Untitled

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright 2009,2010 Ryan Dahl <ry@tinyclouds.org>
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/http_parser.c
+++ b/http_parser.c
@@ -1,4 +1,4 @@
-/* Copyright 2009,2010 Ryan Dahl <ry@tinyclouds.org>
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/http_parser.h
+++ b/http_parser.h
@@ -1,4 +1,4 @@
-/* Copyright 2009,2010 Ryan Dahl <ry@tinyclouds.org>
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/test.c
+++ b/test.c
@@ -1,4 +1,4 @@
-/* Copyright 2009,2010 Ryan Dahl <ry@tinyclouds.org>
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
Consider the following request. This is the complete set of headers. Let's say everything arrives in a single buffer (including the solo CRLF after all headers), which all gets passed to http_parser_execute().

```
CONNECT www.facebook.com:443 HTTP/1.0
Host: www.facebook.com:443
User-Agent: curl/7.15.5 (x86_64-redhat-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8b zlib/1.2.3 libidn/0.6.5
Proxy-Connection: Keep-Alive
```

In the s_headers_almost_done case, we're returning p - data for both on_headers_complete errors and the case of upgrade. As a result, the caller of http_parser_execute() is going to see that this final LF was not consumed. This seems wrong for upgraded connections, and possibly for the error condition as well. After all, the final byte was indeed valid and consumed, right?

It's possible that this bug arises by following the idiom used in other sites which return p - data (via the error path in CALLBACK() and friends). These other sites work because the error path occurs before interrogating the current character, I believe.
