### PR TITLE
HTTP Compliance mods

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -318,6 +318,11 @@ enum flags
 # define NEW_MESSAGE() start_state
 #endif
 
+#if HTTP_PARSER_STRICT_EOL
+# define ACCEPT_LF(ch) (0)
+#else
+# define ACCEPT_LF(ch) (ch == LF)
+#endif
 
 size_t http_parser_execute (http_parser *parser,
                             const http_parser_settings *settings,
@@ -561,7 +566,7 @@ size_t http_parser_execute (http_parser *parser,
           break;
         }
 
-        if (ch == LF) {
+        if (ACCEPT_LF(ch)) {
           state = s_header_field_start;
           break;
         }
@@ -1000,7 +1005,7 @@ size_t http_parser_execute (http_parser *parser,
           break;
         }
 
-        if (ch == LF) {
+        if (ACCEPT_LF(ch)) {
           state = s_header_field_start;
           break;
         }
@@ -1032,7 +1037,7 @@ size_t http_parser_execute (http_parser *parser,
           break;
         }
 
-        if (ch == LF) {
+        if (ACCEPT_LF(ch)) {
           /* they might be just sending \n instead of \r\n so this would be
            * the second \n to denote the end of headers*/
           state = s_headers_almost_done;
@@ -1219,7 +1224,7 @@ size_t http_parser_execute (http_parser *parser,
           break;
         }
 
-        if (ch == LF) {
+        if (ACCEPT_LF(ch)) {
           CALLBACK(header_value);
           state = s_header_field_start;
           break;
@@ -1274,7 +1279,7 @@ size_t http_parser_execute (http_parser *parser,
           break;
         }
 
-        if (ch == LF) {
+        if (ACCEPT_LF(ch)) {
           CALLBACK(header_value);
           goto header_almost_done;
         }

--- a/test.c
+++ b/test.c
@@ -768,13 +768,19 @@ const struct message responses[] =
 
   }
 
+#ifdef HTTP_PARSER_STRICT_EOL
+#define EOL "\r\n"
+#else
+#define EOL "\n"
+#endif
+
 #define NO_CARRIAGE_RET 5
 , {.name="no carriage ret"
   ,.type= HTTP_RESPONSE
-  ,.raw= "HTTP/1.1 200 OK\n"
-         "Content-Type: text/html; charset=utf-8\n"
-         "Connection: close\n"
-         "\n"
+  ,.raw= "HTTP/1.1 200 OK" EOL
+         "Content-Type: text/html; charset=utf-8" EOL
+         "Connection: close" EOL
+         EOL
          "these headers are from http://news.ycombinator.com/"
   ,.should_keep_alive= FALSE
   ,.message_complete_on_eof= TRUE


### PR DESCRIPTION
There are two commits of interest here:

62b68e75    Support mult-line folding in header values.

This patch adds a new state and makes a slight change in the logic to support line folding header values.  The change is pretty minor as the callback is exactly the same.  Secondary lines are called back on the 'on_header_value' function, same as a value that was split over a buffer.  The only logic change is that the parser now ignores a HT white space character after the header field but before any non white space character.

0b21ea2b    Compile option to enforce strict CRLF compliance.

This is probably of less interest, but is a compile option to require CRLF to end header lines.  I added a new macro to enable this so as to not change the current HTTP_PARSER_STRICT logic in the library.  I needed this feature to work around naughty proxies (ie. nginx) forcing LF characters into headers when relaying an SSL certificate to a reverse proxy.
