### PR TITLE
Support ?-terminated hostnames per RFC 2396.3.2.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -719,6 +719,9 @@ size_t http_parser_execute (http_parser *parser,
             CALLBACK(url);
             state = s_req_http_start;
             break;
+          case '?':
+            state = s_req_query_string_start;
+            break;
           default:
             goto error;
         }
@@ -740,6 +743,9 @@ size_t http_parser_execute (http_parser *parser,
              */
             CALLBACK(url);
             state = s_req_http_start;
+            break;
+          case '?':
+            state = s_req_query_string_start;
             break;
           default:
             goto error;

--- a/test.c
+++ b/test.c
@@ -557,7 +557,7 @@ const struct message requests[] =
   ,.body= ""
   }
 
-#define MSEARCH_REQ 19
+#define MSEARCH_REQ 20
 , {.name= "m-search request"
   ,.type= HTTP_REQUEST
   ,.raw= "M-SEARCH * HTTP/1.1\r\n"
@@ -579,6 +579,63 @@ const struct message requests[] =
              , { "MAN", "\"ssdp:discover\"" }
              , { "ST", "\"ssdp:all\"" }
              }
+  ,.body= ""
+  }
+
+#define QUERY_TERMINATED_HOST 21
+, {.name= "host terminated by a query string"
+  ,.type= HTTP_REQUEST
+  ,.raw= "GET http://hypnotoad.org?hail=all HTTP/1.1\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_GET
+  ,.query_string= "hail=all"
+  ,.fragment= ""
+  ,.request_path= ""
+  ,.request_url= "http://hypnotoad.org?hail=all"
+  ,.num_headers= 0
+  ,.headers= { }
+  ,.body= ""
+  }
+
+#define QUERY_TERMINATED_HOSTPORT 22
+, {.name= "host:port terminated by a query string"
+  ,.type= HTTP_REQUEST
+  ,.raw= "GET http://hypnotoad.org:1234?hail=all HTTP/1.1\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_GET
+  ,.query_string= "hail=all"
+  ,.fragment= ""
+  ,.request_path= ""
+  ,.request_url= "http://hypnotoad.org:1234?hail=all"
+  ,.num_headers= 0
+  ,.headers= { }
+  ,.body= ""
+  }
+
+#define SPACE_TERMINATED_HOSTPORT 23
+, {.name= "host:port terminated by a space"
+  ,.type= HTTP_REQUEST
+  ,.raw= "GET http://hypnotoad.org:1234 HTTP/1.1\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_GET
+  ,.query_string= ""
+  ,.fragment= ""
+  ,.request_path= ""
+  ,.request_url= "http://hypnotoad.org:1234"
+  ,.num_headers= 0
+  ,.headers= { }
   ,.body= ""
   }
 


### PR DESCRIPTION
- Bust out of s_req_host and s_req_port on '?'.
- Add tests for query string parsing.
