### PR TITLE
Add 'package' target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OPT_DEBUG=-O0 -g -Wall -Wextra -Werror -I.
 OPT_FAST=-O3 -DHTTP_PARSER_STRICT=0 -I.
 
 CC?=gcc
+AR?=ar
 
 
 test: test_g
@@ -31,11 +32,13 @@ test_fast: http_parser.o test.c http_parser.h
 test-run-timed: test_fast
 	while(true) do time ./test_fast > /dev/null; done
 
+package: http_parser.o
+	$(AR) rcs libhttp_parser.a http_parser.o
 
 tags: http_parser.c http_parser.h test.c
 	ctags $^
 
 clean:
-	rm -f *.o test test_fast test_g http_parser.tar tags
+	rm -f *.o *.a test test_fast test_g http_parser.tar tags
 
 .PHONY: clean package test-run test-run-timed test-valgrind


### PR DESCRIPTION
This target generates the libhttp_parser.a archive file suitable for distribution in a distro-specfic package (.rpm, .deb, etc).
