### PR TITLE
Expose F_* flags as public API.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -314,16 +314,6 @@ enum header_states
   };
 
 
-enum flags
-  { F_CHUNKED               = 1 << 0
-  , F_CONNECTION_KEEP_ALIVE = 1 << 1
-  , F_CONNECTION_CLOSE      = 1 << 2
-  , F_TRAILING              = 1 << 3
-  , F_UPGRADE               = 1 << 4
-  , F_SKIPBODY              = 1 << 5
-  };
-
-
 #define CR '\r'
 #define LF '\n'
 #define LOWER(c) (unsigned char)(c | 0x20)

--- a/http_parser.h
+++ b/http_parser.h
@@ -114,10 +114,21 @@ enum http_method
 enum http_parser_type { HTTP_REQUEST, HTTP_RESPONSE, HTTP_BOTH };
 
 
+/* Flag values for http_parser.flags field */
+enum flags
+  { F_CHUNKED               = 1 << 0
+  , F_CONNECTION_KEEP_ALIVE = 1 << 1
+  , F_CONNECTION_CLOSE      = 1 << 2
+  , F_TRAILING              = 1 << 3
+  , F_UPGRADE               = 1 << 4
+  , F_SKIPBODY              = 1 << 5
+  };
+
+
 struct http_parser {
   /** PRIVATE **/
   unsigned char type : 2;
-  unsigned char flags : 6;
+  unsigned char flags : 6; /* F_* values from 'flags' enum; semi-public */
   unsigned char state;
   unsigned char header_state;
   unsigned char index;


### PR DESCRIPTION
We talked about this a while back.

The idea is to expose flags so that clients of http-parser don't need to re-parse some headers (e.g. Connection: close vs. keep-alive). I would have preferred to split the flags into public/private flags since F_TRAILING and F_SKIPBODY are both a bit wonky, but the bit packing in http_parser made this difficult.
