### PR TITLE
Get rid of CALLBACK_NOCLEAR().

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -58,7 +58,7 @@ do {                                                                 \
   FOR##_mark = p;                                                    \
 } while (0)
 
-#define CALLBACK_NOCLEAR(FOR)                                        \
+#define CALLBACK(FOR)                                                \
 do {                                                                 \
   if (FOR##_mark) {                                                  \
     if (settings->on_##FOR) {                                        \
@@ -70,14 +70,8 @@ do {                                                                 \
         return (p - data);                                           \
       }                                                              \
     }                                                                \
+    FOR##_mark = NULL;                                               \
   }                                                                  \
-} while (0)
-
-
-#define CALLBACK(FOR)                                                \
-do {                                                                 \
-  CALLBACK_NOCLEAR(FOR);                                             \
-  FOR##_mark = NULL;                                                 \
 } while (0)
 
 
@@ -1736,12 +1730,12 @@ size_t http_parser_execute (http_parser *parser,
     }
   }
 
-  CALLBACK_NOCLEAR(header_field);
-  CALLBACK_NOCLEAR(header_value);
-  CALLBACK_NOCLEAR(fragment);
-  CALLBACK_NOCLEAR(query_string);
-  CALLBACK_NOCLEAR(path);
-  CALLBACK_NOCLEAR(url);
+  CALLBACK(header_field);
+  CALLBACK(header_value);
+  CALLBACK(fragment);
+  CALLBACK(query_string);
+  CALLBACK(path);
+  CALLBACK(url);
 
   parser->state = state;
   parser->header_state = header_state;


### PR DESCRIPTION
- This was only used by CALLBACK() (which then cleared the mark anyway),
  and the end of the http_parser_execute() body (after which they
  go out of scope).
