### PR TITLE
RFC: Implement http_pause()

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -177,6 +177,7 @@ enum flags
   XX(INVALID_CONSTANT, "invalid constant string")                    \
   XX(INVALID_INTERNAL_STATE, "encountered unexpected internal state")\
   XX(STRICT, "strict mode assertion failed")                         \
+  XX(PAUSED, "parser is paused")                                     \
   XX(UNKNOWN, "an unknown error occurred")
 
 
@@ -201,20 +202,20 @@ enum http_errno {
 
 struct http_parser {
   /** PRIVATE **/
-  unsigned char type : 2;
-  unsigned char flags : 6; /* F_* values from 'flags' enum; semi-public */
-  unsigned char state;
-  unsigned char header_state;
-  unsigned char index;
+  unsigned char type : 2;     /* enum http_parser_type */
+  unsigned char flags : 6;    /* F_* values from 'flags' enum; semi-public */
+  unsigned char state;        /* enum state from http_parser.c */
+  unsigned char header_state; /* enum header_state from http_parser.c */
+  unsigned char index;        /* index into current matcher */
 
-  uint32_t nread;
-  int64_t content_length;
+  uint32_t nread;          /* # bytes read in various scenarios */
+  int64_t content_length;  /* # bytes in body (0 if no Content-Length header) */
 
   /** READ-ONLY **/
   unsigned short http_major;
   unsigned short http_minor;
   unsigned short status_code; /* responses only */
-  unsigned char method;    /* requests only */
+  unsigned char method;       /* requests only */
   unsigned char http_errno : 7;
 
   /* 1 = Upgrade header was present and the parser has exited because of that.
@@ -303,6 +304,9 @@ const char *http_errno_description(enum http_errno err);
 int http_parser_parse_url(const char *buf, size_t buflen,
                           int is_connect,
                           struct http_parser_url *u);
+
+/* Pause or un-pause the parser; a nonzero value pauses */
+void http_parser_pause(http_parser *parser, int paused);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request is an RFC only. I do not intend to merge it immediately (it needs some better unit tests, for one). That said, it seems to work. I've broken things down into several commits, each of which passes unit tests on its own.

The highlights:
- Add http_pause() API with semantics discussed (causes http_parser_execute() to return with HPE_PAUSED).
- Add test_mesage_pause() test to make sure that we can pause in all callbacks and don't a) get any unexpected callbacks when paused and b) see the data we're expecting when all is said and done.
- Don't use shadow state ('state', 'nread', etc). Instead, update the parser directly. Do this _before_ invoking callbacks so that if the callback results in a paused parser, we're ready to go the next time around.
- Re-factor states that used to invoke multiple callbacks. Each state can now make only a single callback.
- Add NOADVANCE variety of callbacks and 'reexecute_byte' label to handle state transitions that do not consume a byte. Remove gotos that were stand-ins for state transitions.
- Make on_body use standard CALLBACK() macros; this was delicate and might very well be busted.
