### PR TITLE
A struct member rename for compatibility with errno.h

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -34,13 +34,13 @@
 #if HTTP_PARSER_DEBUG
 #define SET_ERRNO(e)                                                 \
 do {                                                                 \
-  parser->errno = (e);                                               \
+  parser->http_errno = (e);                                          \
   parser->error_lineno = __LINE__;                                   \
 } while (0)
 #else
 #define SET_ERRNO(e)                                                 \
 do {                                                                 \
-  parser->errno = (e);                                               \
+  parser->http_errno = (e);                                          \
 } while(0)
 #endif
 
@@ -1760,7 +1760,7 @@ http_parser_init (http_parser *parser, enum http_parser_type t)
   parser->upgrade = 0;
   parser->flags = 0;
   parser->method = 0;
-  parser->errno = 0;
+  parser->http_errno = 0;
 }
 
 const char *

--- a/http_parser.h
+++ b/http_parser.h
@@ -189,7 +189,7 @@ enum http_errno {
 
 
 /* Get an http_errno value from an http_parser */
-#define HTTP_PARSER_ERRNO(p)            ((enum http_errno) (p)->errno)
+#define HTTP_PARSER_ERRNO(p)            ((enum http_errno) (p)->http_errno)
 
 /* Get the line number that generated the current error */
 #if HTTP_PARSER_DEBUG
@@ -215,7 +215,7 @@ struct http_parser {
   unsigned short http_minor;
   unsigned short status_code; /* responses only */
   unsigned char method;    /* requests only */
-  unsigned char errno : 7;
+  unsigned char http_errno : 7;
 
   /* 1 = Upgrade header was present and the parser has exited because of that.
    * 0 = No upgrade header present.


### PR DESCRIPTION
rename parser->errno to parser->http_errno; conflicts with errno.h where errno is defined as a macro
