### PR TITLE
MSVC 2010 Compile Fixes

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -370,6 +370,13 @@ size_t http_parser_execute (http_parser *parser,
   uint64_t index = parser->index;
   uint64_t nread = parser->nread;
 
+  /* technically we could combine all of these (except for url_mark) into one
+     variable, saving stack space, but it seems more clear to have them
+     separated. */
+  const char *header_field_mark = 0;
+  const char *header_value_mark = 0;
+  const char *url_mark = 0;
+
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
     return 0;
@@ -395,13 +402,6 @@ size_t http_parser_execute (http_parser *parser,
         return 1;
     }
   }
-
-  /* technically we could combine all of these (except for url_mark) into one
-     variable, saving stack space, but it seems more clear to have them
-     separated. */
-  const char *header_field_mark = 0;
-  const char *header_value_mark = 0;
-  const char *url_mark = 0;
 
   if (state == s_header_field)
     header_field_mark = data;
@@ -690,12 +690,14 @@ size_t http_parser_execute (http_parser *parser,
 
       case s_req_method:
       {
+        const char *matcher;
+
         if (ch == '\0') {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
         }
 
-        const char *matcher = method_strings[parser->method];
+        matcher = method_strings[parser->method];
         if (ch == ' ' && matcher[index] == '\0') {
           state = s_req_spaces_before_url;
         } else if (ch == matcher[index]) {

--- a/http_parser.h
+++ b/http_parser.h
@@ -27,8 +27,12 @@ extern "C" {
 #define HTTP_PARSER_VERSION_MAJOR 1
 #define HTTP_PARSER_VERSION_MINOR 0
 
+#if RUBY_VERSION >= 190
+#include <ruby/config.h>
+#endif
+
 #include <sys/types.h>
-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(_MSC_VER)
+#if !defined(HAVE_STDINT_H)
 typedef __int8 int8_t;
 typedef unsigned __int8 uint8_t;
 typedef __int16 int16_t;


### PR DESCRIPTION
These are fixes I needed to make to enable compilation with MSVC.  Most of the are simple, moving variable to the top of blocks.  

The other change is for Ruby 1.9 which defines HAVE_STDINT_H in config.h.  VC 2010 now does include this file, so without the check types are redefined twice causing errors.

Thanks - Charlie
