### PR TITLE
Make http-parser compile as C on MSVC

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -364,11 +364,13 @@ size_t http_parser_execute (http_parser *parser,
   char c, ch;
   int8_t unhex_val;
   const char *p = data, *pe;
-  int64_t to_read;
+  size_t to_read;
   enum state state;
   enum header_states header_state;
-  uint64_t index = parser->index;
-  uint64_t nread = parser->nread;
+  size_t index = parser->index;
+  size_t nread = parser->nread;
+  const char *header_field_mark, *header_value_mark, *url_mark;
+  const char *matcher;
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
@@ -399,9 +401,9 @@ size_t http_parser_execute (http_parser *parser,
   /* technically we could combine all of these (except for url_mark) into one
      variable, saving stack space, but it seems more clear to have them
      separated. */
-  const char *header_field_mark = 0;
-  const char *header_value_mark = 0;
-  const char *url_mark = 0;
+  header_field_mark = 0;
+  header_value_mark = 0;
+  url_mark = 0;
 
   if (state == s_header_field)
     header_field_mark = data;
@@ -695,7 +697,7 @@ size_t http_parser_execute (http_parser *parser,
           goto error;
         }
 
-        const char *matcher = method_strings[parser->method];
+        matcher = method_strings[parser->method];
         if (ch == ' ' && matcher[index] == '\0') {
           state = s_req_spaces_before_url;
         } else if (ch == matcher[index]) {
@@ -1576,7 +1578,7 @@ size_t http_parser_execute (http_parser *parser,
       }
 
       case s_body_identity:
-        to_read = MIN(pe - p, (int64_t)parser->content_length);
+        to_read = (size_t)MIN(pe - p, parser->content_length);
         if (to_read > 0) {
           if (settings->on_body) settings->on_body(parser, p, to_read);
           p += to_read - 1;
@@ -1670,14 +1672,14 @@ size_t http_parser_execute (http_parser *parser,
       {
         assert(parser->flags & F_CHUNKED);
 
-        to_read = MIN(pe - p, (int64_t)(parser->content_length));
+        to_read = (size_t)MIN(pe - p, parser->content_length);
 
         if (to_read > 0) {
           if (settings->on_body) settings->on_body(parser, p, to_read);
           p += to_read - 1;
         }
 
-        if (to_read == parser->content_length) {
+        if ((signed)to_read == parser->content_length) {
           state = s_chunk_data_almost_done;
         }
 
@@ -1710,7 +1712,7 @@ size_t http_parser_execute (http_parser *parser,
 
   parser->state = state;
   parser->header_state = header_state;
-  parser->index = index;
+  parser->index = (unsigned char) index;
   parser->nread = nread;
 
   return len;

--- a/http_parser.h
+++ b/http_parser.h
@@ -207,7 +207,7 @@ struct http_parser {
   unsigned char header_state;
   unsigned char index;
 
-  uint32_t nread;
+  size_t nread;
   int64_t content_length;
 
   /** READ-ONLY **/


### PR DESCRIPTION
In libgit2, we're now using http-parser in our network code and with these changes, we're making it compile cleanly as C on MSVC with the highest warning level.

We understand that you currently compile it as C++ but if you could merge this upstream, it'd be great.
