### PR TITLE
stdint.h not included with MSVC versions before 2010

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -28,7 +28,7 @@ extern "C" {
 #define HTTP_PARSER_VERSION_MINOR 0
 
 #include <sys/types.h>
-#if defined(_WIN32) && !defined(__MINGW32__) && !defined(_MSC_VER)
+#if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
 typedef __int8 int8_t;
 typedef unsigned __int8 uint8_t;
 typedef __int16 int16_t;


### PR DESCRIPTION
if using MSVC 2008 or previous, can't assume stdint.h is available
