### PR TITLE
Fix response body is not read

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1733,9 +1733,21 @@ http_should_keep_alive (http_parser *parser)
     /* HTTP/1.1 */
     if (parser->flags & F_CONNECTION_CLOSE) {
       return 0;
-    } else {
+    }
+    if (parser->type == HTTP_REQUEST) {
       return 1;
     }
+    /* see RFC2616 section 4.4 */
+    if (parser->status_code / 100 == 1 || /* 1xx e.g. Continue */
+        parser->status_code == 204 ||     /* No Content */
+        parser->status_code == 304 ||     /* Not Modified */
+        parser->flags & F_SKIPBODY) {     /* response to a HEAD request */
+      return 1;
+    }
+    if (!(parser->flags & F_CHUNKED) && parser->content_length == -1) {
+      return 0;
+    }
+    return 1;
   } else {
     /* HTTP/1.0 or earlier */
     if (parser->flags & F_CONNECTION_KEEP_ALIVE) {

--- a/test.c
+++ b/test.c
@@ -780,8 +780,8 @@ const struct message responses[] =
 , {.name= "404 no headers no body"
   ,.type= HTTP_RESPONSE
   ,.raw= "HTTP/1.1 404 Not Found\r\n\r\n"
-  ,.should_keep_alive= TRUE
-  ,.message_complete_on_eof= FALSE
+  ,.should_keep_alive= FALSE
+  ,.message_complete_on_eof= TRUE
   ,.http_major= 1
   ,.http_minor= 1
   ,.status_code= 404
@@ -795,8 +795,8 @@ const struct message responses[] =
 , {.name= "301 no response phrase"
   ,.type= HTTP_RESPONSE
   ,.raw= "HTTP/1.1 301\r\n\r\n"
-  ,.should_keep_alive = TRUE
-  ,.message_complete_on_eof= FALSE
+  ,.should_keep_alive = FALSE
+  ,.message_complete_on_eof= TRUE
   ,.http_major= 1
   ,.http_minor= 1
   ,.status_code= 301
@@ -1057,8 +1057,46 @@ const struct message responses[] =
     {}
   ,.body= ""
   }
-, {.name= NULL } /* sentinel */
 
+#define NO_CONTENT_LENGTH_NO_TRANSFER_ENCODING_RESPONSE 13
+/* The client should wait for the server's EOF. That is, when neither
+ * content-length nor transfer-encoding is specified, the end of body
+ * is specified by the EOF.
+ */
+, {.name= "neither content-length nor transfer-encoding response"
+  ,.type= HTTP_RESPONSE
+  ,.raw= "HTTP/1.1 200 OK\r\n"
+         "Content-Type: text/plain\r\n"
+         "\r\n"
+         "hello world"
+  ,.should_keep_alive= FALSE
+  ,.message_complete_on_eof= TRUE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.status_code= 200
+  ,.num_headers= 1
+  ,.headers=
+    { { "Content-Type", "text/plain" }
+    }
+  ,.body= "hello world"
+  }
+
+#define NO_HEADERS_NO_BODY_204 14
+, {.name= "204 no headers no body"
+  ,.type= HTTP_RESPONSE
+  ,.raw= "HTTP/1.1 204 No Content\r\n\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.status_code= 204
+  ,.num_headers= 0
+  ,.headers= {}
+  ,.body_size= 0
+  ,.body= ""
+  }
+
+, {.name= NULL } /* sentinel */
 };
 
 int
@@ -1888,7 +1926,7 @@ main (void)
 
   printf("response scan 1/2      ");
   test_scan( &responses[TRAILING_SPACE_ON_CHUNKED_BODY]
-           , &responses[NO_HEADERS_NO_BODY_404]
+           , &responses[NO_HEADERS_NO_BODY_204]
            , &responses[NO_REASON_PHRASE]
            );
 


### PR DESCRIPTION
Related to joyent/node#2457.

With HTTP/1.1, if neither Content-Length nor Transfer-Encoding is present, section 4.4 of RFC 2616 suggests http-parser needs to read a response body until the connection is closed (except the response must not include a body).

e.g.

```
HTTP/1.1 200 OK\r\n
Content-Type: text/plain\r\n
\r\n
...
```

This response can include message body, it does not apply to the following descriptions:

```
1.Any response message which "MUST NOT" include a message-body (such
  as the 1xx, 204, and 304 responses and any response to a HEAD
  request) is always terminated by the first empty line after the
  header fields, regardless of the entity-header fields present in
  the message.
```

`Transfer-Encoding` is not present, it does not apply to the following:

```
2.If a Transfer-Encoding header field (section 14.41) is present and
  has any value other than "identity", then the transfer-length is
  defined by use of the "chunked" transfer-coding (section 3.6),
  unless the message is terminated by closing the connection.
```

`Content-Length`  is not present, it does not apply to the following:

```
3.If a Content-Length header field (section 14.13) is present, its
  decimal value in OCTETs represents both the entity-length and the
  transfer-length. The Content-Length header field MUST NOT be sent
  if these two lengths are different (i.e., if a Transfer-Encoding
  header field is present). If a message is received with both a
  Transfer-Encoding header field and a Content-Length header field,
  the latter MUST be ignored.
```

`Content-Type` is not `multipart/byteranges`, it does not apply to the following:

```
4.If the message uses the media type "multipart/byteranges", and the
  ransfer-length is not otherwise specified, then this self-
  elimiting media type defines the transfer-length. This media type
  UST NOT be used unless the sender knows that the recipient can arse
  it; the presence in a request of a Range header with ultiple byte-
  range specifiers from a 1.1 client implies that the lient can parse
  multipart/byteranges responses.
```

Therefore, the following description is applied:

```
5.By the server closing the connection. (Closing the connection
  cannot be used to indicate the end of a request body, since that
  would leave no possibility for the server to send back a response.)
```
