### PR TITLE
Check for overflow attack on content_length.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1434,6 +1434,12 @@ size_t http_parser_execute (http_parser *parser,
 
             parser->content_length *= 10;
             parser->content_length += ch - '0';
+            
+            if (parser->content_length < 0) {
+              SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+              goto error;
+            }
+            
             break;
 
           /* Transfer-Encoding: chunked */
@@ -1693,6 +1699,12 @@ size_t http_parser_execute (http_parser *parser,
 
         parser->content_length *= 16;
         parser->content_length += unhex_val;
+        
+        if (parser->content_length < 0) {
+          SET_ERRNO(HPE_INVALID_CHUNK_SIZE);
+          goto error;
+        }
+            
         break;
       }
 

--- a/test.c
+++ b/test.c
@@ -2025,6 +2025,86 @@ test_no_overflow_long_body (int req, size_t length)
 }
 
 void
+test_overflow_attack_body (uint64_t length, enum http_errno err)
+{
+  http_parser parser;
+  http_parser_init(&parser, HTTP_REQUEST);
+  size_t parsed;
+	
+  char buf1[3000];
+  size_t buf1len = sprintf(buf1, "%s\r\nConnection: Keep-Alive\r\nContent-Length: %llu\r\n\r\n",
+      "POST / HTTP/1.0", length);
+  parsed = http_parser_execute(&parser, &settings_null, buf1, buf1len);
+
+/*
+  uint64_t i;
+  for ( i = 0; i < length; i++) {
+    char foo = 'a';
+    parsed = http_parser_execute(&parser, &settings_null, &foo, 1);
+    if (parsed != 1)
+      goto err;
+  }
+*/
+
+  if (err)
+  {
+    if (parsed == buf1len || HTTP_PARSER_ERRNO(&parser) != err)
+      goto err;
+  }
+  else if (parsed != buf1len || parser.content_length < 0 || parser.content_length != (int64_t) length)
+    goto err;
+
+  return;
+
+ err:
+  fprintf(stderr,
+          "\n*** error in test_overflow_attack_body %s of length %llu ***\n",
+          "REQUEST",
+          length);
+  exit(1);
+}
+
+void
+test_overflow_attack_chunk (uint64_t length, enum http_errno err)
+{
+  http_parser parser;
+  http_parser_init(&parser, HTTP_REQUEST);
+  size_t parsed;
+	
+  char buf1[3000];
+  size_t buf1len = sprintf(buf1, "%s\r\nConnection: Keep-Alive\r\nTransfer-Encoding: chunked\r\n\r\n%llX\r\n",
+      "POST / HTTP/1.0", length);
+  parsed = http_parser_execute(&parser, &settings_null, buf1, buf1len);
+
+/*
+  uint64_t i;
+  for ( i = 0; i < length; i++) {
+    char foo = 'a';
+    parsed = http_parser_execute(&parser, &settings_null, &foo, 1);
+    if (parsed != 1)
+      goto err;
+  }
+*/
+
+  if (err)
+  {
+    if (parsed == buf1len || HTTP_PARSER_ERRNO(&parser) != err)
+      goto err;
+  }
+  else if (parsed != buf1len || parser.content_length < 0 || parser.content_length != (int64_t) length)
+    goto err;
+
+  return;
+
+ err:
+  fprintf(stderr,
+          "\n*** error in test_overflow_attack_chunk %s of length %llu ***\n",
+          "REQUEST",
+          length);
+  exit(1);
+}
+
+void
 test_multiple3 (const struct message *r1, const struct message *r2, const struct message *r3)
 {
   int message_count = count_parsed_messages(3, r1, r2, r3);
@@ -2304,7 +2384,17 @@ main (void)
   test_header_overflow_error(HTTP_RESPONSE);
   test_no_overflow_long_body(HTTP_RESPONSE, 1000);
   test_no_overflow_long_body(HTTP_RESPONSE, 100000);
-
+  
+  test_overflow_attack_body(9223372036854775807, HPE_OK);
+  test_overflow_attack_body(9223372036854775808ULL, HPE_INVALID_CONTENT_LENGTH);
+  test_overflow_attack_body(9223372036854775809ULL, HPE_INVALID_CONTENT_LENGTH);
+  test_overflow_attack_body(18446744073709551615ULL, HPE_INVALID_CONTENT_LENGTH);
+  
+  test_overflow_attack_chunk(9223372036854775807, HPE_OK);
+  test_overflow_attack_chunk(9223372036854775808ULL, HPE_INVALID_CHUNK_SIZE);
+  test_overflow_attack_chunk(9223372036854775809ULL, HPE_INVALID_CHUNK_SIZE);
+  test_overflow_attack_chunk(18446744073709551615ULL, HPE_INVALID_CHUNK_SIZE);
+  
   //// RESPONSES
 
   for (i = 0; i < response_count; i++) {


### PR DESCRIPTION
  Naughty stuff happens in the parser if an attacker specifies a content-length greater than the max value allowed by int64_t.

  1) If content-length in a header is set to LLONG_MAX+1, parser drops into s_body_identity_eof, which is not technically correct.

  2) If content-length in the header is set to ULLONG_MAX, the parser decides there is a new message (line 1600), and will break on subsequent body data.

  Neither of these are necessarily insecure in and of themselves and obviously unusual, but I would expect a savvy attacker might make use of this, particularly depending on how the parser was being used (say, as in an http proxy).

  If overflow values are used in chunk headers, the situation is worse.

  1) If LLONG_MAX+1 is used in a chunk header and NDEBUG is not defined, an assertion will fail and the app will abort (by default).

  2) If LLONG_MAX+1 is used in a chunk header and NDEBUG is defined, the math gets funky, and the pointer 'p' gets incremented to point to a bad memory address, possibly causing a 'EXC_BAD_ACCESS' segfault.

  I've added a couple simple checks on calculating content_length to error out on the overflow case.  There's probably a more clever and/or efficient way to do this, but this test has the quality of being straight forward and understandable.
