### PR TITLE
Fixes build on MSVC.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -960,7 +960,7 @@ size_t http_parser_execute (http_parser *parser,
         MARK(url);
 
         parser->state = parse_url_char(
-            parser->state, ch, parser->method == HTTP_CONNECT);
+            (enum state)parser->state, ch, parser->method == HTTP_CONNECT);
         if (parser->state == s_dead) {
           SET_ERRNO(HPE_INVALID_URL);
           goto error;
@@ -982,7 +982,7 @@ size_t http_parser_execute (http_parser *parser,
             goto error;
           default:
             parser->state = parse_url_char(
-                parser->state, ch, parser->method == HTTP_CONNECT);
+                (enum state)parser->state, ch, parser->method == HTTP_CONNECT);
             if (parser->state == s_dead) {
               SET_ERRNO(HPE_INVALID_URL);
               goto error;
@@ -1021,7 +1021,7 @@ size_t http_parser_execute (http_parser *parser,
             break;
           default:
             parser->state = parse_url_char(
-                parser->state, ch, parser->method == HTTP_CONNECT);
+                (enum state)parser->state, ch, parser->method == HTTP_CONNECT);
             if (parser->state == s_dead) {
               SET_ERRNO(HPE_INVALID_URL);
               goto error;


### PR DESCRIPTION
The library builds using the C++ compiler shipped with Visual Studio 2008, except that implicit conversion from `unsigned char` to `enum state` is not supported.  An explicit C-style cast allows Microsoft's compiler to build without problems.
