### PR TITLE
Add http_parser_parsing_headers function

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1978,3 +1978,9 @@ http_parser_pause(http_parser *parser, int paused) {
     assert(0 && "Attempting to pause parser in error state");
   }
 }
+
+int http_parser_parsing_headers(http_parser *parser) {
+  return PARSING_HEADER(parser->state);
+}
+
+

--- a/http_parser.h
+++ b/http_parser.h
@@ -308,6 +308,11 @@ int http_parser_parse_url(const char *buf, size_t buflen,
 /* Pause or un-pause the parser; a nonzero value pauses */
 void http_parser_pause(http_parser *parser, int paused);
 
+/* True if currently parsing headers (i.e. read complete
+ * lines to avoid a partial URL/header field/header value)
+ */
+int http_parser_parsing_headers(http_parser *parser);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This just wraps the internal `PARSING_HEADER` macro from http-parser.c.

The idea is that if `http_parser_parsing_headers` returns true, one can read complete lines rather than chunks to avoid receiving a partial URL/header field/header value in the callbacks. This simplified things quite a bit for me, at least.
