### PR TITLE
Fix errors building with older MSVC versions

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#include <http_parser.h>
+#include "http_parser.h"
 #include <assert.h>
 #include <stddef.h>
 #include <ctype.h>


### PR DESCRIPTION
The VC 2008 compiler doesn't like `static inline` for some reason:

```
 http_parser.c(411) : error C2054: expected '(' to follow 'inline'
 http_parser.c(412) : error C2085: 'parse_url_char' : not in formal parameter list
 http_parser.c(412) : error C2143: syntax error : missing ';' before '{'
 http_parser.c(967) : warning C4013: 'parse_url_char' undefined; assuming extern returning int
```

Changing it to `__inline` for MSVC seems to fix this.
