### PR TITLE
Fix building error on Cygwin

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -412,7 +412,7 @@ int http_message_needs_eof(http_parser *parser);
 static enum state
 parse_url_char(enum state s, const char ch, int is_connect)
 {
-  assert(!isspace(ch));
+  assert(!isspace((int) ch));
 
   switch (s) {
     case s_req_spaces_before_url:


### PR DESCRIPTION
Error when building on Cygwin

```
$ make
cc -I. -DHTTP_PARSER_STRICT=1 -DHTTP_PARSER_DEBUG=1  -Wall -Wextra -Werror -O0 -g  -c http_parser.c -o http_parser_g.o
cc1: warnings being treated as errors
http_parser.c: In function ‘parse_url_char’:
http_parser.c:415:3: error: array subscript has type ‘char’
Makefile:26: recipe for target `http_parser_g.o' failed
make: *** [http_parser_g.o] Error 1
```
