### PR TITLE
Replace HTTP methods enum with X-macro map.

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -85,37 +85,43 @@ typedef int (*http_cb) (http_parser*);
 
 
 /* Request Methods */
+#define HTTP_METHOD_MAP(XX) \
+  XX(0, DELETE) \
+  XX(1, GET) \
+  XX(2, HEAD) \
+  XX(3, POST) \
+  XX(4, PUT) \
+  /* pathological */ \
+  XX(5, CONNECT) \
+  XX(6, OPTIONS) \
+  XX(7, TRACE) \
+  /* webdav */ \
+  XX(8, COPY) \
+  XX(9, LOCK) \
+  XX(10, MKCOL) \
+  XX(11, MOVE) \
+  XX(12, PROPFIND) \
+  XX(13, PROPPATCH) \
+  XX(14, UNLOCK) \
+  /* subversion */ \
+  XX(15, REPORT) \
+  XX(16, MKACTIVITY) \
+  XX(17, CHECKOUT) \
+  XX(18, MERGE) \
+  /* upnp */ \
+  XX(19, MSEARCH) \
+  XX(20, NOTIFY) \
+  XX(21, SUBSCRIBE) \
+  XX(22, UNSUBSCRIBE) \
+  /* RFC-5789 */ \
+  XX(23, PATCH) \
+  XX(24, PURGE) \
+
 enum http_method
-  { HTTP_DELETE    = 0
-  , HTTP_GET
-  , HTTP_HEAD
-  , HTTP_POST
-  , HTTP_PUT
-  /* pathological */
-  , HTTP_CONNECT
-  , HTTP_OPTIONS
-  , HTTP_TRACE
-  /* webdav */
-  , HTTP_COPY
-  , HTTP_LOCK
-  , HTTP_MKCOL
-  , HTTP_MOVE
-  , HTTP_PROPFIND
-  , HTTP_PROPPATCH
-  , HTTP_UNLOCK
-  /* subversion */
-  , HTTP_REPORT
-  , HTTP_MKACTIVITY
-  , HTTP_CHECKOUT
-  , HTTP_MERGE
-  /* upnp */
-  , HTTP_MSEARCH
-  , HTTP_NOTIFY
-  , HTTP_SUBSCRIBE
-  , HTTP_UNSUBSCRIBE
-  /* RFC-5789 */
-  , HTTP_PATCH
-  , HTTP_PURGE
+  {
+#define XX(num, name) HTTP_##name = num,
+  HTTP_METHOD_MAP(XX)
+#undef X
   };
 
 


### PR DESCRIPTION
Makes it easier for integrators to generate bindings for the HTTP methods that we support. Example:

``` c++
// stringify method names
const char *methods[] = {
#define XX(num, name) #name,
HTTP_METHOD_MAP(XX)
#undef XX
};
```

I hope and assume that this is an uncontroversial change. :-)
