### PR TITLE
Fix pedantic warnings

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -29,8 +29,10 @@
 #include <string.h>
 #include <limits.h>
 
-#ifndef ULLONG_MAX
-# define ULLONG_MAX ((uint64_t) -1) /* 2^64-1 */
+#if defined(ULLONG_MAX) && __STDC_VERSION__ >= 199901L
+# define HTTP_PARSER_ULLONG_MAX ULLONG_MAX
+#else
+# define HTTP_PARSER_ULLONG_MAX ((uint64_t) -1) /* 2^64-1 */
 #endif
 
 #ifndef MIN
@@ -94,7 +96,7 @@ do {                                                                 \
     FOR##_mark = NULL;                                               \
   }                                                                  \
 } while (0)
-  
+
 /* Run the data callback FOR and consume the current byte */
 #define CALLBACK_DATA(FOR)                                           \
     CALLBACK_DATA_(FOR, p - FOR##_mark, p - data + 1)
@@ -682,7 +684,7 @@ size_t http_parser_execute (http_parser *parser,
         if (ch == CR || ch == LF)
           break;
         parser->flags = 0;
-        parser->content_length = ULLONG_MAX;
+        parser->content_length = HTTP_PARSER_ULLONG_MAX;
 
         if (ch == 'H') {
           parser->state = s_res_or_resp_H;
@@ -717,7 +719,7 @@ size_t http_parser_execute (http_parser *parser,
       case s_start_res:
       {
         parser->flags = 0;
-        parser->content_length = ULLONG_MAX;
+        parser->content_length = HTTP_PARSER_ULLONG_MAX;
 
         switch (ch) {
           case 'H':
@@ -896,7 +898,7 @@ size_t http_parser_execute (http_parser *parser,
         if (ch == CR || ch == LF)
           break;
         parser->flags = 0;
-        parser->content_length = ULLONG_MAX;
+        parser->content_length = HTTP_PARSER_ULLONG_MAX;
 
         if (!IS_ALPHA(ch)) {
           SET_ERRNO(HPE_INVALID_METHOD);
@@ -1480,7 +1482,7 @@ size_t http_parser_execute (http_parser *parser,
             t += ch - '0';
 
             /* Overflow? */
-            if (t < parser->content_length || t == ULLONG_MAX) {
+            if (t < parser->content_length || t == HTTP_PARSER_ULLONG_MAX) {
               SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
               goto error;
             }
@@ -1642,7 +1644,7 @@ size_t http_parser_execute (http_parser *parser,
             /* Content-Length header given but zero: Content-Length: 0\r\n */
             parser->state = NEW_MESSAGE();
             CALLBACK_NOTIFY(message_complete);
-          } else if (parser->content_length != ULLONG_MAX) {
+          } else if (parser->content_length != HTTP_PARSER_ULLONG_MAX) {
             /* Content-Length header given and non-zero */
             parser->state = s_body_identity;
           } else {
@@ -1667,7 +1669,7 @@ size_t http_parser_execute (http_parser *parser,
                                (uint64_t) ((data + len) - p));
 
         assert(parser->content_length != 0
-            && parser->content_length != ULLONG_MAX);
+            && parser->content_length != HTTP_PARSER_ULLONG_MAX);
 
         /* The difference between advancing content_length and p is because
          * the latter will automaticaly advance on the next loop iteration.
@@ -1753,7 +1755,7 @@ size_t http_parser_execute (http_parser *parser,
         t += unhex_val;
 
         /* Overflow? */
-        if (t < parser->content_length || t == ULLONG_MAX) {
+        if (t < parser->content_length || t == HTTP_PARSER_ULLONG_MAX) {
           SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
           goto error;
         }
@@ -1796,7 +1798,7 @@ size_t http_parser_execute (http_parser *parser,
 
         assert(parser->flags & F_CHUNKED);
         assert(parser->content_length != 0
-            && parser->content_length != ULLONG_MAX);
+            && parser->content_length != HTTP_PARSER_ULLONG_MAX);
 
         /* See the explanation in s_body_identity for why the content
          * length and data pointers are managed this way.
@@ -1881,7 +1883,7 @@ http_message_needs_eof (http_parser *parser)
     return 0;
   }
 
-  if ((parser->flags & F_CHUNKED) || parser->content_length != ULLONG_MAX) {
+  if ((parser->flags & F_CHUNKED) || parser->content_length != HTTP_PARSER_ULLONG_MAX) {
     return 0;
   }
 


### PR DESCRIPTION
Hi all, this patch will fix nasty warnings in pedantic mode and also use long long constants more carefully (only for C99 compilers) 

```
$ CFLAGS='-pedantic -Werror' make library
In file included from http_parser.c:24:0:
http_parser.h:123:3: error: comma at end of enumerator list [-Werror=edantic]
http_parser.h:190:3: error: comma at end of enumerator list [-Werror=edantic]
http_parser.h:208:3: error: type of bit-field ‘type’ is a GCC extension [-Werror=edantic]
http_parser.h:209:3: error: type of bit-field ‘flags’ is a GCC extension [-Werror=edantic]
http_parser.h:222:3: error: type of bit-field ‘http_errno’ is a GCC extension [-Werror=edantic]
http_parser.h:229:3: error: type of bit-field ‘upgrade’ is a GCC extension [-Werror=edantic]
http_parser.c: In function ‘http_parser_execute’:
http_parser.c:685:34: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:685:34: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:720:34: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:720:34: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:899:34: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:899:34: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1483:52: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1483:52: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1645:48: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1645:48: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1670:52: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1670:52: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1756:48: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1756:48: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1799:52: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1799:52: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c: In function ‘http_message_needs_eof’:
http_parser.c:1884:64: error: use of C99 long long integer constant [-Werror=long-long]
http_parser.c:1884:64: error: use of C99 long long integer constant [-Werror=long-long]
cc1: all warnings being treated as errors
make: *** [libhttp_parser.o] Error 1
```
