### PR TITLE
Ignoring .so files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test_g
 test_fast
 *.mk
 *.Makefile
+*.so


### PR DESCRIPTION
The .so file generated by the `library` target wasn't being ignored by git.
