### PR TITLE
Ignore output of package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test_fast
 *.mk
 *.Makefile
 *.so
+*.a


### PR DESCRIPTION
`make package` generates a `.a` file that isn't being ignored by git.
