### PR TITLE
Expose variables/functions for dynamic bindings.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -29,6 +29,9 @@
 #include <string.h>
 #include <limits.h>
 
+#define STRINGIZE(x) _STRINGIZE(x)
+#define _STRINGIZE(x) #x
+
 const unsigned int http_parser_debug = HTTP_PARSER_DEBUG;
 
 #ifndef ULLONG_MAX
@@ -2058,4 +2061,9 @@ http_parser_pause(http_parser *parser, int paused) {
   } else {
     assert(0 && "Attempting to pause parser in error state");
   }
+}
+
+const char *
+http_parser_version() {
+  return STRINGIZE(HTTP_PARSER_VERSION_MAJOR.HTTP_PARSER_VERSION_MINOR);
 }

--- a/http_parser.h
+++ b/http_parser.h
@@ -27,6 +27,8 @@ extern "C" {
 #define HTTP_PARSER_VERSION_MAJOR 1
 #define HTTP_PARSER_VERSION_MINOR 0
 
+const char * http_parser_version();
+
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
 typedef __int8 int8_t;


### PR DESCRIPTION
Added the `http_parser_debug` constant variable and the `http_parser_version()` function, for dynamic bindings. Foreign Function Interface (FFI) bindings cannot access the macros, and instead require exposed variables/functions.
