### PR TITLE
Make size_t and ssize_t Windows typedefs more appropriate

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -29,6 +29,7 @@ extern "C" {
 
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
+#include <BaseTsd.h>
 typedef __int8 int8_t;
 typedef unsigned __int8 uint8_t;
 typedef __int16 int16_t;
@@ -37,9 +38,8 @@ typedef __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
-
-typedef unsigned int size_t;
-typedef int ssize_t;
+typedef SIZE_T size_t;
+typedef SSIZE_T ssize_t;
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
The typedefs for `size_t` and `ssize_t` on Windows had them as `unsigned int` and `int`.  It's more appropriate to use `SIZE_T` and `SSIZE_T` from BaseTsd.h (which also prevents http_parser.h from conflicting with similar typedefs using the correct types).
