### PR TITLE
Replace MSVC size_t typedef with stddef.h

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -30,6 +30,7 @@ extern "C" {
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
 #include <BaseTsd.h>
+#include <stddef.h>
 typedef __int8 int8_t;
 typedef unsigned __int8 uint8_t;
 typedef __int16 int16_t;
@@ -38,8 +39,6 @@ typedef __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
-typedef SIZE_T size_t;
-typedef SSIZE_T ssize_t;
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
This seems to resolve https://github.com/udp/lacewing/issues/60 and https://github.com/joyent/http-parser/pull/128 by replacing the manual size_t typedef with a stddef.h include.
