### PR TITLE
Parse Status Messages to makte them available in Node.js

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -823,6 +823,7 @@ size_t http_parser_execute (http_parser *parser,
         if (!IS_NUM(ch)) {
           switch (ch) {
             case ' ':
+              parser->status_msg_length = 0;
               parser->state = s_res_status;
               break;
             case CR:
@@ -855,11 +856,13 @@ size_t http_parser_execute (http_parser *parser,
         if (ch == CR) {
           parser->state = s_res_line_almost_done;
           break;
-        }
-
-        if (ch == LF) {
+        }else if (ch == LF) {
           parser->state = s_header_field_start;
           break;
+        }else{          
+          if(parser->status_msg_length < 4096){
+            parser->status_msg[parser->status_msg_length++] = ch;
+          }
         }
         break;
 

--- a/http_parser.h
+++ b/http_parser.h
@@ -204,6 +204,8 @@ struct http_parser {
   unsigned short http_major;
   unsigned short http_minor;
   unsigned short status_code; /* responses only */
+  char status_msg[4096];      /* responses only */
+  unsigned short status_msg_length;
   unsigned char method;       /* requests only */
   unsigned char http_errno : 7;
 


### PR DESCRIPTION
I've requested a feature on node.js where I can access the status message of responses, so I decided to add this feature to the http_parser.

https://github.com/joyent/node/issues/4614
