### PR TITLE
Parse the reason phrase to make it available to NodeJs

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -892,7 +892,6 @@ size_t http_parser_execute (http_parser *parser,
       case s_res_line_almost_done:
         STRICT_CHECK(ch != LF);
         parser->state = s_header_field_start;
-        CALLBACK_NOTIFY(status_complete);
         break;
 
       case s_start_req:

--- a/http_parser.h
+++ b/http_parser.h
@@ -142,7 +142,6 @@ enum flags
                                                                      \
   /* Callback-related errors */                                      \
   XX(CB_message_begin, "the on_message_begin callback failed")       \
-  XX(CB_status_complete, "the on_status_complete callback failed")   \
   XX(CB_url, "the on_url callback failed")                           \
   XX(CB_header_field, "the on_header_field callback failed")         \
   XX(CB_header_value, "the on_header_value callback failed")         \
@@ -225,7 +224,6 @@ struct http_parser_settings {
   http_cb      on_message_begin;
   http_data_cb on_url;
   http_data_cb on_status;
-  http_cb      on_status_complete;
   http_data_cb on_header_field;
   http_data_cb on_header_value;
   http_cb      on_headers_complete;

--- a/test.c
+++ b/test.c
@@ -1529,13 +1529,6 @@ request_url_cb (http_parser *p, const char *buf, size_t len)
 }
 
 int
-status_complete_cb (http_parser *p) {
-  assert(p == parser);
-  p->data++;
-  return 0;
-}
-
-int
 header_field_cb (http_parser *p, const char *buf, size_t len)
 {
   assert(p == parser);
@@ -3166,20 +3159,6 @@ create_large_chunked_message (int body_size_in_kb, const char* headers)
   return buf;
 }
 
-void
-test_status_complete (void)
-{
-  parser_init(HTTP_RESPONSE);
-  parser->data = 0;
-  http_parser_settings settings = settings_null;
-  settings.on_status_complete = status_complete_cb;
-
-  char *response = "don't mind me, just a simple response";
-  http_parser_execute(parser, &settings, response, strlen(response));
-  assert(parser->data == (void*)0); // the status_complete callback was never called
-  assert(parser->http_errno == HPE_INVALID_CONSTANT); // the errno for an invalid status line
-}
-
 /* Verify that we can pause parsing at any of the bytes in the
  * message and still get the result that we're expecting. */
 void
@@ -3487,8 +3466,6 @@ main (void)
            , &requests[PREFIX_NEWLINE_GET ]
            , &requests[CONNECT_REQUEST]
            );
-
-  test_status_complete();
 
   puts("requests okay");
 


### PR DESCRIPTION
Hey guys,

there is an open pull request that is five months old to allow the status message to be parsed. You can see this here: joyent/http-parser/pull/149.

I believe this related to this feature request: Feature Request on node.js: joyent/node#4614

These changes build on VanCoding's changes by fixing the tests, refactoring the style slightly (to make it more consistent with the rest of the file) and adding an extra test for another case that was previously untested. 

I understand there has been some discussion in the community as to whether this feature is actually useful. I'm happy to explain why I think it is useful if necessary.
