### PR TITLE
Do not accept PUN/GEM methods as PUT/GET.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -947,6 +947,7 @@ size_t http_parser_execute (http_parser *parser,
           if (parser->index == 1 && ch == 'E') {
             parser->method = HTTP_SEARCH;
           } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
           }
         } else if (parser->index == 1 && parser->method == HTTP_POST) {
@@ -957,13 +958,27 @@ size_t http_parser_execute (http_parser *parser,
           } else if (ch == 'A') {
             parser->method = HTTP_PATCH;
           } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
           }
         } else if (parser->index == 2) {
           if (parser->method == HTTP_PUT) {
-            if (ch == 'R') parser->method = HTTP_PURGE;
+            if (ch == 'R') {
+              parser->method = HTTP_PURGE;
+            } else {
+              SET_ERRNO(HPE_INVALID_METHOD);
+              goto error;
+            }
           } else if (parser->method == HTTP_UNLOCK) {
-            if (ch == 'S') parser->method = HTTP_UNSUBSCRIBE;
+            if (ch == 'S') {
+              parser->method = HTTP_UNSUBSCRIBE;
+            } else {
+              SET_ERRNO(HPE_INVALID_METHOD);
+              goto error;
+            }
+          } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
           }
         } else if (parser->index == 4 && parser->method == HTTP_PROPFIND && ch == 'P') {
           parser->method = HTTP_PROPPATCH;

--- a/test.c
+++ b/test.c
@@ -3265,7 +3265,10 @@ main (void)
 
   test_simple("hello world", HPE_INVALID_METHOD);
   test_simple("GET / HTP/1.1\r\n\r\n", HPE_INVALID_VERSION);
-
+  test_simple("GEM / HTTP/1.1\r\n\r\n", HPE_INVALID_METHOD);
+  test_simple("PUN / HTTP/1.1\r\n\r\n", HPE_INVALID_METHOD);
+  test_simple("PX / HTTP/1.1\r\n\r\n", HPE_INVALID_METHOD);
+  test_simple("SA / HTTP/1.1\r\n\r\n", HPE_INVALID_METHOD);
 
   test_simple("ASDF / HTTP/1.1\r\n\r\n", HPE_INVALID_METHOD);
   test_simple("PROPPATCHA / HTTP/1.1\r\n\r\n", HPE_INVALID_METHOD);


### PR DESCRIPTION
- Encountering them returns an error, `HPE_INVALID_METHOD`
- Tests have been added.

There's not a clear distinction between what erroneous methods should trigger `HPE_INVALID_METHOD` vs. `HPE_UNKNOWN` (there are extant tests for `HPE_UNKNOWN` against methods like "C*****"), advice would be appreciated. Tested with `make test` on OSX 10.7.5.

This fixes joyent/node#6078.
