### PR TITLE
Add two hooks to be executed when a chunk is downloaded.

### DIFF
--- a/contrib/parsertrace.c
+++ b/contrib/parsertrace.c
@@ -47,6 +47,18 @@ int on_message_complete(http_parser* _) {
   return 0;
 }
 
+int on_chunk_begin(http_parser* _) {
+  (void)_;
+  printf("\n***CHUNK BEGIN***\n\n");
+  return 0;
+}
+
+int on_chunk_complete(http_parser* _) {
+  (void)_;
+  printf("\n***CHUNK COMPLETE***\n\n");
+  return 0;
+}
+
 int on_url(http_parser* _, const char* at, size_t length) {
   (void)_;
   printf("Url: %.*s\n", (int)length, at);
@@ -136,7 +148,9 @@ int main(int argc, char* argv[]) {
   settings.on_header_field = on_header_field;
   settings.on_header_value = on_header_value;
   settings.on_headers_complete = on_headers_complete;
+  settings.on_chunk_begin = on_chunk_begin;
   settings.on_body = on_body;
+  settings.on_chunk_complete = on_chunk_complete;
   settings.on_message_complete = on_message_complete;
 
   http_parser parser;

--- a/http_parser.c
+++ b/http_parser.c
@@ -1782,6 +1782,7 @@ size_t http_parser_execute (http_parser *parser,
           parser->state = s_header_field_start;
         } else {
           parser->state = s_chunk_data;
+          CALLBACK_NOTIFY(chunk_begin);
         }
         break;
       }
@@ -1822,6 +1823,7 @@ size_t http_parser_execute (http_parser *parser,
         STRICT_CHECK(ch != LF);
         parser->nread = 0;
         parser->state = s_chunk_size_start;
+        CALLBACK_NOTIFY(chunk_complete);
         break;
 
       default:

--- a/http_parser.h
+++ b/http_parser.h
@@ -148,7 +148,9 @@ enum flags
   XX(CB_header_field, "the on_header_field callback failed")         \
   XX(CB_header_value, "the on_header_value callback failed")         \
   XX(CB_headers_complete, "the on_headers_complete callback failed") \
+  XX(CB_chunk_begin, "the on_chunk_begin callback failed")           \
   XX(CB_body, "the on_body callback failed")                         \
+  XX(CB_chunk_complete, "the on_chunk_complete callback failed")     \
   XX(CB_message_complete, "the on_message_complete callback failed") \
                                                                      \
   /* Parsing-related errors */                                       \
@@ -228,7 +230,9 @@ struct http_parser_settings {
   http_data_cb on_header_field;
   http_data_cb on_header_value;
   http_cb      on_headers_complete;
+  http_cb      on_chunk_begin;
   http_data_cb on_body;
+  http_cb      on_chunk_complete;
   http_cb      on_message_complete;
 };
 


### PR DESCRIPTION
One hook is executed right before receiving a new chunk. The second
one is executed just after. parsertrace.c is updated to use those
hooks for display.

I am using this for experimentation with rendering. This is more reliable than looking at timestamps to know where chunks start and end.
