### PR TITLE
Don't abort silently a test if a strict-mode check fails.

### DIFF
--- a/test.c
+++ b/test.c
@@ -3134,13 +3134,7 @@ test_message_pause (const struct message *msg)
     }
 
     if (nread < buflen) {
-
-      // Not much do to if we failed a strict-mode check
-      if (HTTP_PARSER_ERRNO(parser) == HPE_STRICT) {
-        parser_free();
-        return;
-      }
-
+      assert (HTTP_PARSER_ERRNO(parser) != HPE_STRICT);
       assert (HTTP_PARSER_ERRNO(parser) == HPE_PAUSED);
     }
 


### PR DESCRIPTION
In `test_message_pause()`, we don't expect a strict-mode check to
fail. Don't abort silently the test if it is the case. Raise an assert
error instead. We keep a separate assert to help with debugging.