### PR TITLE
Use unsigned int as bitfield type

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -193,11 +193,11 @@ enum http_errno {
 
 struct http_parser {
   /** PRIVATE **/
-  unsigned char type : 2;     /* enum http_parser_type */
-  unsigned char flags : 6;    /* F_* values from 'flags' enum; semi-public */
-  unsigned char state;        /* enum state from http_parser.c */
-  unsigned char header_state; /* enum header_state from http_parser.c */
-  unsigned char index;        /* index into current matcher */
+  unsigned int type : 2;         /* enum http_parser_type */
+  unsigned int flags : 6;        /* F_* values from 'flags' enum; semi-public */
+  unsigned int state : 8;        /* enum state from http_parser.c */
+  unsigned int header_state : 8; /* enum header_state from http_parser.c */
+  unsigned int index : 8;        /* index into current matcher */
 
   uint32_t nread;          /* # bytes read in various scenarios */
   uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
@@ -205,16 +205,16 @@ struct http_parser {
   /** READ-ONLY **/
   unsigned short http_major;
   unsigned short http_minor;
-  unsigned short status_code; /* responses only */
-  unsigned char method;       /* requests only */
-  unsigned char http_errno : 7;
+  unsigned int status_code : 16; /* responses only */
+  unsigned int method : 8;       /* requests only */
+  unsigned int http_errno : 7;
 
   /* 1 = Upgrade header was present and the parser has exited because of that.
    * 0 = No upgrade header present.
    * Should be checked when http_parser_execute() returns in addition to
    * error checking.
    */
-  unsigned char upgrade : 1;
+  unsigned int upgrade : 1;
 
   /** PUBLIC **/
   void *data; /* A pointer to get hook to the "connection" or "socket" object */


### PR DESCRIPTION
Compiling any file that includes `http_parser.h` with `-pedantic` on GCC gives this warning:

```
inc/http_parser.h:196:3: warning: type of bit-field ‘type’ is a GCC extension [-pedantic]
inc/http_parser.h:197:3: warning: type of bit-field ‘flags’ is a GCC extension [-pedantic]
inc/http_parser.h:210:3: warning: type of bit-field ‘http_errno’ is a GCC extension [-pedantic]
inc/http_parser.h:217:3: warning: type of bit-field ‘upgrade’ is a GCC extension [-pedantic]
```

This pull request changes the types of the members of both bitfields in `struct http_parser` to be `unsigned int`, which fixes this warning.

This _should_ pack just as well as what's there currently. On gcc 4.2.1 at least, there's no change in the total size of `struct http_parser` after applying this patch.
