### PR TITLE
Fix some issues with multi-line headers

### DIFF
--- a/test.c
+++ b/test.c
@@ -601,8 +601,14 @@ const struct message requests[] =
          "  mno \r\n"
          "\t \tqrs\r\n"
          "Line2: \t line2\t\r\n"
+         "Line3:\r\n"
+         " line3\r\n"
+         "Line4: \r\n"
+         " \r\n"
+         "Connection:\r\n"
+         " close\r\n"
          "\r\n"
-  ,.should_keep_alive= TRUE
+  ,.should_keep_alive= FALSE
   ,.message_complete_on_eof= FALSE
   ,.http_major= 1
   ,.http_minor= 1
@@ -611,9 +617,12 @@ const struct message requests[] =
   ,.fragment= ""
   ,.request_path= "/"
   ,.request_url= "/"
-  ,.num_headers= 2
+  ,.num_headers= 5
   ,.headers= { { "Line1", "abc\tdef ghi\t\tjkl  mno \t \tqrs" }
              , { "Line2", "line2\t" }
+             , { "Line3", "line3" }
+             , { "Line4", "" }
+             , { "Connection", "close" },
              }
   ,.body= ""
   }
@@ -894,6 +903,43 @@ const struct message requests[] =
   ,.port= 1234
   ,.num_headers= 0
   ,.headers= { }
+  ,.body= ""
+  }
+
+#define LINE_FOLDING_IN_HEADER_WITH_LF 34
+, {.name= "line folding in header value"
+  ,.type= HTTP_REQUEST
+  ,.raw= "GET / HTTP/1.1\n"
+         "Line1:   abc\n"
+         "\tdef\n"
+         " ghi\n"
+         "\t\tjkl\n"
+         "  mno \n"
+         "\t \tqrs\n"
+         "Line2: \t line2\t\n"
+         "Line3:\n"
+         " line3\n"
+         "Line4: \n"
+         " \n"
+         "Connection:\n"
+         " close\n"
+         "\n"
+  ,.should_keep_alive= FALSE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_GET
+  ,.query_string= ""
+  ,.fragment= ""
+  ,.request_path= "/"
+  ,.request_url= "/"
+  ,.num_headers= 5
+  ,.headers= { { "Line1", "abc\tdef ghi\t\tjkl  mno \t \tqrs" }
+             , { "Line2", "line2\t" }
+             , { "Line3", "line3" }
+             , { "Line4", "" }
+             , { "Connection", "close" },
+             }
   ,.body= ""
   }
 


### PR DESCRIPTION
These commits fix some issues to do with multi-line headers.  See the commit comments for details.

Note that the second commit fixes a bug that might have security implications, because it can lead to Content-Length and Transfer-Encoding header values being ignored.  But the practical risk is probably small because proxies and reverse proxies are supposed to normalize requests and responses these days.
