### PR TITLE
Allow HTTP_MAX_HEADER_SIZE to be defined externally

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -653,7 +653,7 @@ size_t http_parser_execute (http_parser *parser,
        * than any reasonable request or response so this should never affect
        * day-to-day operation.
        */
-      if (parser->nread > HTTP_MAX_HEADER_SIZE) {
+      if (parser->nread > (HTTP_MAX_HEADER_SIZE)) {
         SET_ERRNO(HPE_HEADER_OVERFLOW);
         goto error;
       }

--- a/http_parser.h
+++ b/http_parser.h
@@ -52,9 +52,16 @@ typedef unsigned __int64 uint64_t;
 # define HTTP_PARSER_STRICT 1
 #endif
 
-/* Maximium header size allowed */
-#define HTTP_MAX_HEADER_SIZE (80*1024)
-
+/* Maximium header size allowed. If the macro is not defined
+ * before including this header then the default is used. To
+ * change the maximum header size, define the macro in the build
+ * environment (e.g. -DHTTP_MAX_HEADER_SIZE=<value>). To remove
+ * the effective limit on the size of the header, define the macro
+ * to a very large number (e.g. -DHTTP_MAX_HEADER_SIZE=0x7fffffff)
+ */
+#ifndef HTTP_MAX_HEADER_SIZE
+# define HTTP_MAX_HEADER_SIZE (80*1024)
+#endif
 
 typedef struct http_parser http_parser;
 typedef struct http_parser_settings http_parser_settings;


### PR DESCRIPTION
This lets the value of HTTP_MAX_HEADER_SIZE be chosen externally simply by defining the macro either in the build environment or before including the header and source files.
