### PR TITLE
drop CLA requirement

### DIFF
--- a/CONTRIBUTIONS
+++ b/CONTRIBUTIONS
@@ -1,4 +1,0 @@
-Contributors must agree to the Contributor License Agreement before patches
-can be accepted.
-
-http://spreadsheets2.google.com/viewform?hl=en&formkey=dDJXOGUwbzlYaWM4cHN1MERwQS1CSnc6MQ


### PR DESCRIPTION
According to https://github.com/joyent/node/commit/f6ba61bd1545a72636eb02b213772dd221b681be, node.js team removed it. So I assume it's no longer applicable in this repo.

ref https://github.com/joyent/http-parser/pull/158#issuecomment-46010002
