### PR TITLE
Solaris doesn't necessarily have stdint.h, use inttypes.h

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -42,6 +42,8 @@ typedef __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
+#elif (defined(__sun) || defined(__sun__)) && defined(__SunOS_5_9)
+#include <sys/inttypes.h>
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
Solaris doesn't necessarily have `stdint.h`, it's more portable to use `sys/inttypes.h`.

See:
http://wiki.opencsw.org/porting-faq#toc1
