### PR TITLE
RFC-7230 Sec 3.2.4 expressly forbids line-folding in header field-names.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1390,18 +1390,6 @@ size_t http_parser_execute (http_parser *parser,
           break;
         }
 
-        if (ch == CR) {
-          parser->state = s_header_almost_done;
-          CALLBACK_DATA(header_field);
-          break;
-        }
-
-        if (ch == LF) {
-          parser->state = s_header_field_start;
-          CALLBACK_DATA(header_field);
-          break;
-        }
-
         SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
         goto error;
       }

--- a/test.c
+++ b/test.c
@@ -3476,6 +3476,13 @@ main (void)
     test_simple(buf, HPE_INVALID_METHOD);
   }
 
+  // illegal header field name line folding
+  test_simple("GET / HTTP/1.1\r\n"
+              "name\r\n"
+              " : value\r\n"
+              "\r\n",
+              HPE_INVALID_HEADER_TOKEN);
+
   const char *dumbfuck2 =
     "GET / HTTP/1.1\r\n"
     "X-SSL-Bullshit:   -----BEGIN CERTIFICATE-----\r\n"


### PR DESCRIPTION
This change no longer allows obsolete line-folding between the header
field-name and the colon. If HTTP_PARSER_STRICT is unset, the parser
still allows space characters.
