### PR TITLE
Added support for SOURCE

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -969,7 +969,7 @@ size_t http_parser_execute (http_parser *parser,
             /* or PROPFIND|PROPPATCH|PUT|PATCH|PURGE */
             break;
           case 'R': parser->method = HTTP_REPORT; break;
-          case 'S': parser->method = HTTP_SUBSCRIBE; /* or SEARCH */ break;
+          case 'S': parser->method = HTTP_SUBSCRIBE; /* or SEARCH, SOURCE */ break;
           case 'T': parser->method = HTTP_TRACE; break;
           case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE */ break;
           default:
@@ -1023,6 +1023,8 @@ size_t http_parser_execute (http_parser *parser,
         } else if (parser->method == HTTP_SUBSCRIBE) {
           if (parser->index == 1 && ch == 'E') {
             parser->method = HTTP_SEARCH;
+          } else if(parser->index == 1 && ch == 'O') {
+            parser->method = HTTP_SOURCE;
           } else {
             SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
@@ -1791,7 +1793,8 @@ size_t http_parser_execute (http_parser *parser,
         parser->upgrade =
           ((parser->flags & (F_UPGRADE | F_CONNECTION_UPGRADE)) ==
            (F_UPGRADE | F_CONNECTION_UPGRADE) ||
-           parser->method == HTTP_CONNECT);
+           parser->method == HTTP_CONNECT ||
+           parser->method == HTTP_SOURCE);
 
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we

--- a/http_parser.h
+++ b/http_parser.h
@@ -119,6 +119,8 @@ typedef int (*http_cb) (http_parser*);
   XX(25, PURGE,       PURGE)        \
   /* CalDAV */                      \
   XX(26, MKCALENDAR,  MKCALENDAR)   \
+  /* Icecast */                     \
+  XX(27, SOURCE,      SOURCE)       \
 
 enum http_method
   {

--- a/test.c
+++ b/test.c
@@ -986,6 +986,44 @@ const struct message requests[] =
   ,.body= ""
   }
 
+  #define ICY_SOURCE 36
+, {.name= "icecast source"
+  ,.type= HTTP_REQUEST
+  ,.raw= "SOURCE /stream HTTP/1.0\r\n"
+         "Authorization: Basic c291cmNlOmhhY2ttZQ==\r\n"
+         "ice-bitrate: 112\r\n"
+         "ice-name: \r\n"
+         "ice-genre: \r\n"
+         "ice-description: \r\n"
+         "ice-url: \r\n"
+         "ice-public: 1\r\n"
+         "User-Agent: aucast/1.0\r\n"
+         "Content-Type: audio/mpeg\r\n"
+         "\r\n"
+  ,.should_keep_alive= FALSE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 0
+  ,.method= HTTP_SOURCE
+  ,.query_string= ""
+  ,.fragment= ""
+  ,.request_path= "/stream"
+  ,.request_url= "/stream"
+  ,.num_headers= 9
+  ,.headers=
+    { { "Authorization", "Basic c291cmNlOmhhY2ttZQ==" }
+    , { "ice-bitrate", "112" }
+    , { "ice-name", "" }
+    , { "ice-genre", "" }
+    , { "ice-description", "" }
+    , { "ice-url", "" }
+    , { "ice-public", "1" }
+    , { "User-Agent", "aucast/1.0" }
+    , { "Content-Type", "audio/mpeg" }
+    }
+  ,.body= ""
+  }
+
 
 , {.name= NULL } /* sentinel */
 };
@@ -3479,6 +3517,7 @@ main (void)
     "SUBSCRIBE",
     "UNSUBSCRIBE",
     "PATCH",
+    "SOURCE",
     0 };
   const char **this_method;
   for (this_method = all_methods; *this_method; this_method++) {


### PR DESCRIPTION
As per tweets: https://twitter.com/indutny/status/557499042243289088

It seems new handling for upgrade was added at some point, which makes the tests break. Unfortunately I don't have time to work out how to make the tests pass again.

SOURCE should essentially be handled like Upgrade, I believe, and switched to data/tcp mode after parsing headers.

/cc @indutny @bnoordhuis 
