### PR TITLE
src: introduce `http_parser_url_init`

### DIFF
--- a/contrib/url_parser.c
+++ b/contrib/url_parser.c
@@ -35,6 +35,7 @@ int main(int argc, char ** argv) {
   connect = strcmp("connect", argv[1]) == 0 ? 1 : 0;
   printf("Parsing %s, connect %d\n", argv[2], connect);
 
+  http_parser_url_init(&u);
   result = http_parser_parse_url(argv[2], len, connect, &u);
   if (result != 0) {
     printf("Parse error : %d\n", result);

--- a/http_parser.c
+++ b/http_parser.c
@@ -2292,6 +2292,11 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
   return 0;
 }
 
+void
+http_parser_url_init(struct http_parser_url *u) {
+  memset(u, 0, sizeof(*u));
+}
+
 int
 http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
                       struct http_parser_url *u)

--- a/http_parser.h
+++ b/http_parser.h
@@ -318,6 +318,9 @@ const char *http_errno_name(enum http_errno err);
 /* Return a string description of the given error */
 const char *http_errno_description(enum http_errno err);
 
+/* Initialize all http_parser_url members to 0 */
+void http_parser_url_init(struct http_parser_url *u);
+
 /* Parse a URL; return nonzero on failure */
 int http_parser_parse_url(const char *buf, size_t buflen,
                           int is_connect,


### PR DESCRIPTION
The struct must be zero-initialized, but this wasn't explicitly stated
anywhere in headers. Introduce `http_parser_url_init` API method that
will do it.

Fix #209 

cc @bnoordhuis 