### PR TITLE
Allow repeatable calls to 'make install'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,12 +113,12 @@ tags: http_parser.c http_parser.h test.c
 install: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
+	ln -f -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
 
 install-strip: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
+	ln -f -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
 
 uninstall:
 	rm $(INCLUDEDIR)/http_parser.h


### PR DESCRIPTION
Currently if `make install` is invoked multiple times it fails due to it trying to recreate the `libhttp_parser.so` symlink. 

Adding the `-f` flag to the `ln` invocations fixes this, but will change the default http-parser used to the newly installed version if there are multiple versions installed. I _think_ this is what we want to do anyway since we are clobbering any existing `http-parser.h` during install, so not repointing the symlink would result in a mismatch between the default library and header versions.

The alternative would be to version `http-parser.h` and add a symlink for it, while trying to ensure we always update both symlinks atomically.
