### PR TITLE
Tolerate non-compliant status line responses

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -881,10 +881,9 @@ reexecute:
               UPDATE_STATE(s_res_status_start);
               break;
             case CR:
-              UPDATE_STATE(s_res_line_almost_done);
-              break;
             case LF:
-              UPDATE_STATE(s_header_field_start);
+              UPDATE_STATE(s_res_status_start);
+              REEXECUTE();
               break;
             default:
               SET_ERRNO(HPE_INVALID_STATUS);
@@ -906,19 +905,13 @@ reexecute:
 
       case s_res_status_start:
       {
-        if (ch == CR) {
-          UPDATE_STATE(s_res_line_almost_done);
-          break;
-        }
-
-        if (ch == LF) {
-          UPDATE_STATE(s_header_field_start);
-          break;
-        }
-
         MARK(status);
         UPDATE_STATE(s_res_status);
         parser->index = 0;
+
+        if (ch == CR || ch == LF)
+            REEXECUTE();
+
         break;
       }
 


### PR DESCRIPTION
Tolerate web servers which do not return a status message in the return response.

I have noticed this usse on several websites such downloads from mediafire.com
