### PR TITLE
Add support for LINK/UNLINK methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ Romain Giraud <giraud.romain@gmail.com>
 Jay Satiro <raysatiro@yahoo.com>
 Arne Steen <Arne.Steen@gmx.de>
 Kjell Schubert <kjell.schubert@gmail.com>
+Olivier Mengué <dolmen@cpan.org>

--- a/http_parser.h
+++ b/http_parser.h
@@ -124,6 +124,9 @@ typedef int (*http_cb) (http_parser*);
   XX(29, PURGE,       PURGE)        \
   /* CalDAV */                      \
   XX(30, MKCALENDAR,  MKCALENDAR)   \
+  /* RFC-2068, section 19.6.1.2 */  \
+  XX(31, LINK,        LINK)         \
+  XX(32, UNLINK,      UNLINK)       \
 
 enum http_method
   {

--- a/test.c
+++ b/test.c
@@ -1101,6 +1101,58 @@ const struct message requests[] =
   ,.body= ""
   }
 
+/* Examples from the Internet draft for LINK/UNLINK methods:
+ * https://tools.ietf.org/id/draft-snell-link-method-01.html#rfc.section.5
+ */
+
+#define LINK_REQUEST 40
+, {.name = "link request"
+  ,.type= HTTP_REQUEST
+  ,.raw= "LINK /images/my_dog.jpg HTTP/1.1\r\n"
+         "Host: example.com\r\n"
+         "Link: <http://example.com/profiles/joe>; rel=\"tag\"\r\n"
+         "Link: <http://example.com/profiles/sally>; rel=\"tag\"\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_LINK
+  ,.request_path= "/images/my_dog.jpg"
+  ,.request_url= "/images/my_dog.jpg"
+  ,.query_string= ""
+  ,.fragment= ""
+  ,.num_headers= 3
+  ,.headers= { { "Host", "example.com" }
+             , { "Link", "<http://example.com/profiles/joe>; rel=\"tag\"" }
+	     , { "Link", "<http://example.com/profiles/sally>; rel=\"tag\"" }
+             }
+  ,.body= ""
+  }
+
+#define UNLINK_REQUEST 41
+, {.name = "link request"
+  ,.type= HTTP_REQUEST
+  ,.raw= "UNLINK /images/my_dog.jpg HTTP/1.1\r\n"
+         "Host: example.com\r\n"
+         "Link: <http://example.com/profiles/sally>; rel=\"tag\"\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_UNLINK
+  ,.request_path= "/images/my_dog.jpg"
+  ,.request_url= "/images/my_dog.jpg"
+  ,.query_string= ""
+  ,.fragment= ""
+  ,.num_headers= 2
+  ,.headers= { { "Host", "example.com" }
+	     , { "Link", "<http://example.com/profiles/sally>; rel=\"tag\"" }
+             }
+  ,.body= ""
+  }
+
 , {.name= NULL } /* sentinel */
 };
 
@@ -3760,6 +3812,8 @@ main (void)
     "PATCH",
     "PURGE",
     "MKCALENDAR",
+    "LINK",
+    "UNLINK",
     0 };
   const char **this_method;
   for (this_method = all_methods; *this_method; this_method++) {


### PR DESCRIPTION
Add support for HTTP methods LINK and UNLINK originally defined in RFC2068 section 19.6.2.2, but with semantic being added in a Internet draft.
https://tools.ietf.org/html/rfc2068#section-19.6.1.2
https://tools.ietf.org/html/draft-snell-link-method-12