### PR TITLE
readme: update travis link to new nodejs org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HTTP Parser
 ===========
 
-[![Build Status](https://travis-ci.org/joyent/http-parser.png?branch=master)](https://travis-ci.org/joyent/http-parser)
+[![Build Status](https://travis-ci.org/nodejs/http-parser.svg?branch=master)](https://travis-ci.org/joyent/http-parser)
 
 This is a parser for HTTP messages written in C. It parses both requests and
 responses. The parser is designed to be used in performance HTTP


### PR DESCRIPTION
The Travis CI badge still points to the "old" joyent/http-parser logo, which doesn't exist.