### PR TITLE
Invalid header chars fix

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1572,7 +1572,7 @@ reexecute:
             REEXECUTE();
           }
 
-          if (!lenient && !IS_HEADER_CHAR(ch)) {
+          if (!lenient && !IS_HEADER_CHAR((unsigned char)ch)) {
             SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
             goto error;
           }


### PR DESCRIPTION
*I'm not a C programmer, sorry for that*.

Real use case: nginx + maxmind geobase + user from Düsseldorf will generate something like this

```
curl -vvv http://localhost:8000 -H 'GEOIP_CITY: Düsseldorf'
```

This request will cause empty response (with `HPE_INVALID_HEADER_TOKEN`) from nodejs because of `ü`. And seems like it is valid character for headers (`%x80-FF`) but in `IS_HEADER_CHAR` we get a negative char value (cause of signed char is -127..127), so I just casted `ch` to unsigned char before check.

Bad things happened with nodejs v5.6.0 in this commit https://github.com/nodejs/node/commit/98fde2f6a75bc979bd7c749c59bbe3193adae2a1.