### PR TITLE
Version bump: http-parser-2.6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,14 @@ PLATFORM ?= $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
 HELPER ?=
 BINEXT ?=
 ifeq (darwin,$(PLATFORM))
-SONAME ?= libhttp_parser.2.6.1.dylib
+SONAME ?= libhttp_parser.2.6.2.dylib
 SOEXT ?= dylib
 else ifeq (wine,$(PLATFORM))
 CC = winegcc
 BINEXT = .exe.so
 HELPER = wine
 else
-SONAME ?= libhttp_parser.so.2.6.1
+SONAME ?= libhttp_parser.so.2.6.2
 SOEXT ?= so
 endif
 

--- a/http_parser.c
+++ b/http_parser.c
@@ -123,7 +123,7 @@ do {                                                                 \
     FOR##_mark = NULL;                                               \
   }                                                                  \
 } while (0)
-  
+
 /* Run the data callback FOR and consume the current byte */
 #define CALLBACK_DATA(FOR)                                           \
     CALLBACK_DATA_(FOR, p - FOR##_mark, p - data + 1)
@@ -440,7 +440,7 @@ enum http_host_state
  * character or %x80-FF
  **/
 #define IS_HEADER_CHAR(ch)                                                     \
-  (ch == CR || ch == LF || ch == 9 || (ch > 31 && ch != 127))
+  (ch == CR || ch == LF || ch == 9 || ((unsigned char)ch > 31 && ch != 127))
 
 #define start_state (parser->type == HTTP_REQUEST ? s_start_req : s_start_res)
 

--- a/http_parser.h
+++ b/http_parser.h
@@ -27,7 +27,7 @@ extern "C" {
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
 #define HTTP_PARSER_VERSION_MINOR 6
-#define HTTP_PARSER_VERSION_PATCH 1
+#define HTTP_PARSER_VERSION_PATCH 2
 
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && \

--- a/test.c
+++ b/test.c
@@ -3933,6 +3933,11 @@ main (void)
 
   test_simple("GET / HTP/1.1\r\n\r\n", HPE_INVALID_VERSION);
 
+  // Extended characters - see nodejs/test/parallel/test-http-headers-obstext.js
+  test_simple("GET / HTTP/1.1\r\n"
+              "Test: Düsseldorf\r\n",
+              HPE_OK);
+
   // Well-formed but incomplete
   test_simple("GET / HTTP/1.1\r\n"
               "Content-Type: text/plain\r\n"


### PR DESCRIPTION
This is an adaption of the bump that was introduced in the nodejs tree. Hopefully we can improve this workflow moving forward since we're adding subtle discrepancies between the codebases.

Also, add a test for obstext characters.

Guessing this could be dropped in favour of #283 (and moving the test commit there). Your call.