### PR TITLE
Microsoft C++ compiler fails when assert is before decls

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2250,11 +2250,12 @@ http_parse_host_char(enum http_host_state s, const char ch) {
 
 static int
 http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
-  assert(u->field_set & (1 << UF_HOST));
   enum http_host_state s;
 
   const char *p;
   size_t buflen = u->field_data[UF_HOST].off + u->field_data[UF_HOST].len;
+
+  assert(u->field_set & (1 << UF_HOST));
 
   u->field_data[UF_HOST].len = 0;
 


### PR DESCRIPTION
Microsoft C++ compiler fails when this assert appears before the declarations. Moved assert to appear after the declarations.