### PR TITLE
Added support for compiling on MinGW platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@
 # IN THE SOFTWARE.
 
 PLATFORM ?= $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
+ifeq ($(findstring mingw,$(PLATFORM)), mingw)
+PLATFORM = mingw
+endif
+
 HELPER ?=
 BINEXT ?=
 ifeq (darwin,$(PLATFORM))
@@ -28,6 +32,10 @@ else ifeq (wine,$(PLATFORM))
 CC = winegcc
 BINEXT = .exe.so
 HELPER = wine
+else ifeq (mingw,$(PLATFORM))
+CC = gcc
+SONAME ?= libhttp_parser.2.6.2.dll
+SOEXT  ?= dll
 else
 SONAME ?= libhttp_parser.so.2.6.2
 SOEXT ?= so
@@ -50,7 +58,11 @@ CFLAGS += -Wall -Wextra -Werror
 CFLAGS_DEBUG = $(CFLAGS) -O0 -g $(CFLAGS_DEBUG_EXTRA)
 CFLAGS_FAST = $(CFLAGS) -O3 $(CFLAGS_FAST_EXTRA)
 CFLAGS_BENCH = $(CFLAGS_FAST) -Wno-unused-parameter
+ifneq (mingw,$(PLATFORM))
 CFLAGS_LIB = $(CFLAGS_FAST) -fPIC
+else
+CFLAGS_LIB = $(CFLAGS_FAST)
+endif
 
 LDFLAGS_LIB = $(LDFLAGS) -shared
 
@@ -141,7 +153,7 @@ clean:
 	rm -f *.o *.a tags test test_fast test_g \
 		http_parser.tar libhttp_parser.so.* \
 		url_parser url_parser_g parsertrace parsertrace_g \
-		*.exe *.exe.so
+		*.exe *.exe.so *.dll
 
 contrib/url_parser.c:	http_parser.h
 contrib/parsertrace.c:	http_parser.h


### PR DESCRIPTION
Added rules to compile on MinGW platforms (Microsoft Windows environments):
- Use 'gcc' as compiler.
- Generate DLL file when compiling the library.
- Disable -fPIC when compiling the library (on MinGW platforms all code is already position independent and setting this flag issues an error).
