### PR TITLE
Fix: suppress warning C4244 on MSVC

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -29,6 +29,11 @@
 #include <string.h>
 #include <limits.h>
 
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable:4244) // warning C4244: '=' : conversion from 'int' to 'uint16_t', possible loss of data
+#endif //_MSC_VER
+
 #ifndef ULLONG_MAX
 # define ULLONG_MAX ((uint64_t) -1) /* 2^64-1 */
 #endif
@@ -2463,3 +2468,7 @@ http_parser_version(void) {
          HTTP_PARSER_VERSION_MINOR * 0x00100 |
          HTTP_PARSER_VERSION_PATCH * 0x00001;
 }
+
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif //_MSC_VER


### PR DESCRIPTION
MSVC 2015 gives some warnings on http_parser.c with 

> warning C4244: '=' : conversion from 'int' to 'uint16_t', possible loss of data
> It will supress this warning.
