### PR TITLE
Fix error: variable ‘nread’ set but not used

### DIFF
--- a/test.c
+++ b/test.c
@@ -3850,11 +3850,10 @@ test_message_connect (const struct message *msg)
 {
   char *buf = (char*) msg->raw;
   size_t buflen = strlen(msg->raw);
-  size_t nread;
 
   parser_init(msg->type);
 
-  nread = parse_connect(buf, buflen);
+  parse_connect(buf, buflen);
 
   if (num_messages != 1) {
     printf("\n*** num_messages != 1 after testing '%s' ***\n\n", msg->name);


### PR DESCRIPTION
```
cc  -I. -DHTTP_PARSER_STRICT=0  -Wall -Wextra -Werror -O3  -c test.c -o test.o
test.c: In function ‘test_message_connect’:
test.c:3853:10: error: variable ‘nread’ set but not used [-Werror=unused-but-set-variable]
   size_t nread;
          ^~~~~
cc1: all warnings being treated as errors
```