### PR TITLE
Allow non-standard HTTP method

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -280,6 +280,7 @@ enum state
   { s_dead = 1 /* important that this is > 0 */
 
   , s_start_req_or_res
+  , s_res_or_resp_mark_H
   , s_res_or_resp_H
   , s_start_res
   , s_res_H
@@ -298,7 +299,11 @@ enum state
 
   , s_start_req
 
+  , s_req_method_start
   , s_req_method
+#if HTTP_PARSER_METHOD_CB
+  , s_req_method_unknown
+#endif
   , s_req_spaces_before_url
   , s_req_schema
   , s_req_schema_slash
@@ -644,6 +649,9 @@ size_t http_parser_execute (http_parser *parser,
   const char *url_mark = 0;
   const char *body_mark = 0;
   const char *status_mark = 0;
+#if HTTP_PARSER_METHOD_CB
+  const char *method_mark = 0;
+#endif
   enum state p_state = (enum state) parser->state;
   const unsigned int lenient = parser->lenient_http_headers;
 
@@ -692,6 +700,14 @@ size_t http_parser_execute (http_parser *parser,
   case s_req_fragment:
     url_mark = data;
     break;
+#if HTTP_PARSER_METHOD_CB
+  case s_res_or_resp_H:
+  case s_req_method_start:
+  case s_req_method:
+  case s_req_method_unknown:
+    method_mark = data;
+    break;
+#endif
   case s_res_status:
     status_mark = data;
     break;
@@ -726,9 +742,10 @@ reexecute:
         parser->content_length = ULLONG_MAX;
 
         if (ch == 'H') {
-          UPDATE_STATE(s_res_or_resp_H);
+          UPDATE_STATE(s_res_or_resp_mark_H);
 
-          CALLBACK_NOTIFY(message_begin);
+          CALLBACK_NOTIFY_NOADVANCE(message_begin);
+          REEXECUTE();
         } else {
           parser->type = HTTP_REQUEST;
           UPDATE_STATE(s_start_req);
@@ -738,19 +755,46 @@ reexecute:
         break;
       }
 
+      case s_res_or_resp_mark_H:
+        assert(ch == 'H');
+        UPDATE_STATE(s_res_or_resp_H);
+#if HTTP_PARSER_METHOD_CB
+        /* TODO This will call on_method even if type == HTTP_BOTH is
+         * used and it later turns out that this is response.
+         * Automatic handling bites us hard.
+         */
+        MARK(method);
+#endif
+        break;
+
       case s_res_or_resp_H:
         if (ch == 'T') {
           parser->type = HTTP_RESPONSE;
           UPDATE_STATE(s_res_HT);
         } else {
+#if HTTP_PARSER_METHOD_CB
+          if (UNLIKELY(!TOKEN(ch))) {
+            SET_ERRNO(HPE_INVALID_CONSTANT);
+            goto error;
+          }
+
+          if (UNLIKELY(ch != 'E')) {
+            parser->method = HTTP_METHOD_UNKNOWN;
+          } else {
+            parser->method = HTTP_HEAD;
+            parser->index = 2;
+          }
+#else
           if (UNLIKELY(ch != 'E')) {
             SET_ERRNO(HPE_INVALID_CONSTANT);
             goto error;
           }
 
-          parser->type = HTTP_REQUEST;
           parser->method = HTTP_HEAD;
           parser->index = 2;
+#endif
+
+          parser->type = HTTP_REQUEST;
           UPDATE_STATE(s_req_method);
         }
         break;
@@ -952,11 +996,29 @@ reexecute:
         break;
 
       case s_start_req:
-      {
         if (ch == CR || ch == LF)
           break;
         parser->flags = 0;
         parser->content_length = ULLONG_MAX;
+
+        if (UNLIKELY(!IS_ALPHA(ch))) {
+          SET_ERRNO(HPE_INVALID_METHOD);
+          goto error;
+        }
+
+        UPDATE_STATE(s_req_method_start);
+#if HTTP_PARSER_METHOD_CB
+        MARK(method);
+#endif
+
+        CALLBACK_NOTIFY_NOADVANCE(message_begin);
+        REEXECUTE();
+
+        break;
+
+      case s_req_method_start:
+      {
+        enum state next_state = s_req_method;
 
         if (UNLIKELY(!IS_ALPHA(ch))) {
           SET_ERRNO(HPE_INVALID_METHOD);
@@ -984,12 +1046,26 @@ reexecute:
           case 'T': parser->method = HTTP_TRACE; break;
           case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE, UNBIND, UNLINK */ break;
           default:
+#if HTTP_PARSER_METHOD_CB
+            if (UNLIKELY(!TOKEN(ch))) {
+              SET_ERRNO(HPE_INVALID_METHOD);
+              goto error;
+            }
+
+            parser->method = (unsigned int) HTTP_METHOD_UNKNOWN;
+
+            next_state = s_req_method_unknown;
+#else
             SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
+#endif
         }
-        UPDATE_STATE(s_req_method);
 
-        CALLBACK_NOTIFY(message_begin);
+        UPDATE_STATE(next_state);
+
+#if HTTP_PARSER_METHOD_CB
+        MARK(method);
+#endif
 
         break;
       }
@@ -1003,8 +1079,21 @@ reexecute:
         }
 
         matcher = method_strings[parser->method];
-        if (ch == ' ' && matcher[parser->index] == '\0') {
+
+        if (ch == ' ') {
+          if (matcher[parser->index] != '\0') {
+#if HTTP_PARSER_METHOD_CB
+            parser->method = (unsigned int) HTTP_METHOD_UNKNOWN;
+#else
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
+#endif
+          }
+
           UPDATE_STATE(s_req_spaces_before_url);
+#if HTTP_PARSER_METHOD_CB
+          CALLBACK_DATA(method);
+#endif
         } else if (ch == matcher[parser->index]) {
           ; /* nada */
         } else if (IS_ALPHA(ch)) {
@@ -1034,14 +1123,56 @@ reexecute:
 #undef XX
 
             default:
+#if HTTP_PARSER_METHOD_CB
+              if (UNLIKELY(!TOKEN(ch))) {
+                SET_ERRNO(HPE_INVALID_METHOD);
+                goto error;
+              }
+
+              parser->method = (unsigned int) HTTP_METHOD_UNKNOWN;
+
+              UPDATE_STATE(s_req_method_unknown);
+#else
               SET_ERRNO(HPE_INVALID_METHOD);
               goto error;
+#endif
           }
         } else if (ch == '-' &&
                    parser->index == 1 &&
                    parser->method == HTTP_MKCOL) {
           parser->method = HTTP_MSEARCH;
         } else {
+#if HTTP_PARSER_METHOD_CB
+          if (UNLIKELY(!TOKEN(ch))) {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
+          }
+
+          parser->method = (unsigned int) HTTP_METHOD_UNKNOWN;
+
+          UPDATE_STATE(s_req_method_unknown);
+#else
+          SET_ERRNO(HPE_INVALID_METHOD);
+          goto error;
+#endif
+        }
+
+        ++parser->index;
+        break;
+      }
+
+#if HTTP_PARSER_METHOD_CB
+      case s_req_method_unknown:
+      {
+        if (UNLIKELY(ch == '\0')) {
+          SET_ERRNO(HPE_INVALID_METHOD);
+          goto error;
+        }
+
+        if (ch == ' ') {
+          UPDATE_STATE(s_req_spaces_before_url);
+          CALLBACK_DATA(method);
+        } else if (UNLIKELY(!TOKEN(ch))) {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
         }
@@ -1049,6 +1180,7 @@ reexecute:
         ++parser->index;
         break;
       }
+#endif
 
       case s_req_spaces_before_url:
       {
@@ -2078,6 +2210,9 @@ reexecute:
   CALLBACK_DATA_NOADVANCE(url);
   CALLBACK_DATA_NOADVANCE(body);
   CALLBACK_DATA_NOADVANCE(status);
+#if HTTP_PARSER_METHOD_CB
+  CALLBACK_DATA_NOADVANCE(method);
+#endif
 
   RETURN(len);
 

--- a/http_parser.h
+++ b/http_parser.h
@@ -53,6 +53,17 @@ typedef unsigned __int64 uint64_t;
 # define HTTP_PARSER_STRICT 1
 #endif
 
+/* Compile with -DHTTP_PARSER_METHOD_CB=1 to enable method
+ * callback. If it is enabled, method string is notified with
+ * on_method callback.  The unknown method which would be rejeted
+ * previously is also accepted and notified with the on_method
+ * callback.  The method field of http_parser struct becomes
+ * HTTP_METHOD_UNKNOWN if method is unknown to http_parser.
+ */
+#ifndef HTTP_PARSER_METHOD_CB
+# define HTTP_PARSER_METHOD_CB 0
+#endif
+
 /* Maximium header size allowed. If the macro is not defined
  * before including this header then the default is used. To
  * change the maximum header size, define the macro in the build
@@ -140,6 +151,8 @@ enum http_method
 #undef XX
   };
 
+/* Unknown HTTP method */
+#define HTTP_METHOD_UNKNOWN 255
 
 enum http_parser_type { HTTP_REQUEST, HTTP_RESPONSE, HTTP_BOTH };
 
@@ -176,6 +189,7 @@ enum flags
   XX(CB_status, "the on_status callback failed")                     \
   XX(CB_chunk_header, "the on_chunk_header callback failed")         \
   XX(CB_chunk_complete, "the on_chunk_complete callback failed")     \
+  XX(CB_method, "the on_method callback failed")                     \
                                                                      \
   /* Parsing-related errors */                                       \
   XX(INVALID_EOF_STATE, "stream ended at an unexpected time")        \
@@ -217,7 +231,6 @@ enum http_errno {
 
 /* Get an http_errno value from an http_parser */
 #define HTTP_PARSER_ERRNO(p)            ((enum http_errno) (p)->http_errno)
-
 
 struct http_parser {
   /** PRIVATE **/
@@ -264,6 +277,7 @@ struct http_parser_settings {
    */
   http_cb      on_chunk_header;
   http_cb      on_chunk_complete;
+  http_data_cb on_method;
 };
 
 

--- a/test.c
+++ b/test.c
@@ -52,6 +52,7 @@ struct message {
   enum http_method method;
   int status_code;
   char response_status[MAX_ELEMENT_SIZE];
+  char request_method[MAX_ELEMENT_SIZE];
   char request_path[MAX_ELEMENT_SIZE];
   char request_url[MAX_ELEMENT_SIZE];
   char fragment[MAX_ELEMENT_SIZE];
@@ -103,6 +104,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/test"
@@ -134,6 +136,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/favicon.ico"
@@ -163,6 +166,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/dumbfuck"
@@ -184,6 +188,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= "page=1"
   ,.fragment= "posts-17408"
   ,.request_path= "/forums/1/topics/2375"
@@ -203,6 +208,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/get_no_headers_no_body/world"
@@ -222,6 +228,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/get_one_header_no_body"
@@ -245,6 +252,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 0
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/get_funky_content_length_body_hello"
@@ -270,6 +278,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.query_string= "q=search"
   ,.fragment= "hey"
   ,.request_path= "/post_identity_body_world"
@@ -297,6 +306,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/post_chunked_all_your_base"
@@ -325,6 +335,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/two_chunks_mult_zero_end"
@@ -355,6 +366,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/chunked_w_trailing_headers"
@@ -385,6 +397,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/chunked_w_bullshit_after_length"
@@ -407,6 +420,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= "foo=\"bar\""
   ,.fragment= ""
   ,.request_path= "/with_\"stupid\"_quotes"
@@ -433,6 +447,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 0
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/test"
@@ -456,6 +471,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= "foo=bar?baz"
   ,.fragment= ""
   ,.request_path= "/test.cgi"
@@ -477,6 +493,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/test"
@@ -504,6 +521,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/demo"
@@ -535,6 +553,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 0
   ,.method= HTTP_CONNECT
+  ,.request_method = "CONNECT"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= ""
@@ -557,6 +576,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_REPORT
+  ,.request_method = "REPORT"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/test"
@@ -576,6 +596,7 @@ const struct message requests[] =
   ,.http_major= 0
   ,.http_minor= 9
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/"
@@ -598,6 +619,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_MSEARCH
+  ,.request_method = "M-SEARCH"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "*"
@@ -633,6 +655,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/"
@@ -658,6 +681,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= "hail=all"
   ,.fragment= ""
   ,.request_path= ""
@@ -678,6 +702,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= "hail=all"
   ,.fragment= ""
   ,.request_path= ""
@@ -699,6 +724,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= ""
@@ -725,6 +751,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_PATCH
+  ,.request_method = "PATCH"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/file.txt"
@@ -750,6 +777,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 0
   ,.method= HTTP_CONNECT
+  ,.request_method = "CONNECT"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= ""
@@ -774,6 +802,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= "q=1"
   ,.fragment= "narf"
   ,.request_path= "/δ¶/δt/pope"
@@ -796,6 +825,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 0
   ,.method= HTTP_CONNECT
+  ,.request_method = "CONNECT"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= ""
@@ -823,6 +853,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/"
@@ -851,6 +882,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/"
@@ -876,6 +908,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_PURGE
+  ,.request_method = "PURGE"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/file.txt"
@@ -896,6 +929,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_SEARCH
+  ,.request_method = "SEARCH"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/"
@@ -915,6 +949,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.fragment= ""
   ,.request_path= "/toto"
   ,.request_url= "http://a%12:b!&*$@hypnotoad.org:1234/toto"
@@ -949,6 +984,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/"
@@ -982,6 +1018,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/demo"
@@ -1012,6 +1049,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/demo"
@@ -1037,6 +1075,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_GET
+  ,.request_method = "GET"
   ,.query_string= ""
   ,.fragment= ""
   ,.request_path= "/demo"
@@ -1065,6 +1104,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_POST
+  ,.request_method = "POST"
   ,.request_path= "/demo"
   ,.request_url= "/demo"
   ,.num_headers= 4
@@ -1091,6 +1131,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 0
   ,.method= HTTP_CONNECT
+  ,.request_method = "CONNECT"
   ,.request_url= "foo.bar.com:443"
   ,.num_headers= 3
   ,.upgrade="blarfcicle"
@@ -1118,6 +1159,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_LINK
+  ,.request_method = "LINK"
   ,.request_path= "/images/my_dog.jpg"
   ,.request_url= "/images/my_dog.jpg"
   ,.query_string= ""
@@ -1142,6 +1184,7 @@ const struct message requests[] =
   ,.http_major= 1
   ,.http_minor= 1
   ,.method= HTTP_UNLINK
+  ,.request_method = "UNLINK"
   ,.request_path= "/images/my_dog.jpg"
   ,.request_url= "/images/my_dog.jpg"
   ,.query_string= ""
@@ -1152,6 +1195,30 @@ const struct message requests[] =
              }
   ,.body= ""
   }
+
+#if HTTP_PARSER_METHOD_CB
+#define UNKNOWN_METHOD 42
+, {.name="unknown method"
+  ,.type= HTTP_REQUEST
+  ,.raw= "NON-STANDARD-METHOD / HTTP/1.1\r\n"
+         "Host: example.com\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_METHOD_UNKNOWN
+  ,.request_method= "NON-STANDARD-METHOD"
+  ,.query_string= ""
+  ,.fragment= ""
+  ,.request_path= "/"
+  ,.request_url= "/"
+  ,.num_headers= 1
+  ,.headers=
+   { { "Host", "example.com" } }
+  ,.body= ""
+  }
+#endif
 
 , {.name= NULL } /* sentinel */
 };
@@ -1815,6 +1882,19 @@ strlcpy(char *dst, const char *src, size_t len)
   return strlncpy(dst, len, src, (size_t) -1);
 }
 
+#if HTTP_PARSER_METHOD_CB
+int
+request_method_cb(http_parser *p, const char *buf, size_t len)
+{
+  assert(p == parser);
+  strlncat(messages[num_messages].request_method,
+           sizeof(messages[num_messages].request_method),
+           buf,
+           len);
+  return 0;
+}
+#endif
+
 int
 request_url_cb (http_parser *p, const char *buf, size_t len)
 {
@@ -2117,6 +2197,16 @@ pause_header_value_cb (http_parser *p, const char *buf, size_t len)
   return header_value_cb(p, buf, len);
 }
 
+#if HTTP_PARSER_METHOD_CB
+int
+pause_request_method_cb (http_parser *p, const char *buf, size_t len)
+{
+  http_parser_pause(p, 1);
+  *current_pause_parser = settings_dontcall;
+  return request_method_cb(p, buf, len);
+}
+#endif
+
 int
 pause_request_url_cb (http_parser *p, const char *buf, size_t len)
 {
@@ -2198,6 +2288,9 @@ static http_parser_settings settings_pause =
   ,.on_message_complete = pause_message_complete_cb
   ,.on_chunk_header = pause_chunk_header_cb
   ,.on_chunk_complete = pause_chunk_complete_cb
+#if HTTP_PARSER_METHOD_CB
+  ,.on_method = pause_request_method_cb
+#endif
   };
 
 static http_parser_settings settings =
@@ -2211,6 +2304,9 @@ static http_parser_settings settings =
   ,.on_message_complete = message_complete_cb
   ,.on_chunk_header = chunk_header_cb
   ,.on_chunk_complete = chunk_complete_cb
+#if HTTP_PARSER_METHOD_CB
+  ,.on_method = request_method_cb
+#endif
   };
 
 static http_parser_settings settings_count_body =
@@ -2224,6 +2320,9 @@ static http_parser_settings settings_count_body =
   ,.on_message_complete = message_complete_cb
   ,.on_chunk_header = chunk_header_cb
   ,.on_chunk_complete = chunk_complete_cb
+#if HTTP_PARSER_METHOD_CB
+  ,.on_method = request_method_cb
+#endif
   };
 
 static http_parser_settings settings_connect =
@@ -2237,6 +2336,9 @@ static http_parser_settings settings_connect =
   ,.on_message_complete = connect_message_complete_cb
   ,.on_chunk_header = chunk_header_cb
   ,.on_chunk_complete = chunk_complete_cb
+#if HTTP_PARSER_METHOD_CB
+  ,.on_method = request_method_cb
+#endif
   };
 
 static http_parser_settings settings_null =
@@ -2250,6 +2352,9 @@ static http_parser_settings settings_null =
   ,.on_message_complete = 0
   ,.on_chunk_header = 0
   ,.on_chunk_complete = 0
+#if HTTP_PARSER_METHOD_CB
+  ,.on_method = 0
+#endif
   };
 
 void
@@ -2376,6 +2481,9 @@ message_eq (int index, int connect, const struct message *expected)
 
   if (expected->type == HTTP_REQUEST) {
     MESSAGE_CHECK_NUM_EQ(expected, m, method);
+#if HTTP_PARSER_METHOD_CB
+    MESSAGE_CHECK_STR_EQ(expected, m, request_method);
+#endif
   } else {
     MESSAGE_CHECK_NUM_EQ(expected, m, status_code);
     MESSAGE_CHECK_STR_EQ(expected, m, response_status);
@@ -3850,11 +3958,10 @@ test_message_connect (const struct message *msg)
 {
   char *buf = (char*) msg->raw;
   size_t buflen = strlen(msg->raw);
-  size_t nread;
 
   parser_init(msg->type);
 
-  nread = parse_connect(buf, buflen);
+  parse_connect(buf, buflen);
 
   if (num_messages != 1) {
     printf("\n*** num_messages != 1 after testing '%s' ***\n\n", msg->name);
@@ -4074,7 +4181,15 @@ main (void)
   for (this_method = bad_methods; *this_method; this_method++) {
     char buf[200];
     sprintf(buf, "%s / HTTP/1.1\r\n\r\n", *this_method);
+#if HTTP_PARSER_METHOD_CB
+    if (strchr(*this_method, ' ')) {
+      test_simple(buf, HPE_INVALID_URL);
+    } else {
+      test_simple(buf, HPE_OK);
+    }
+#else
     test_simple(buf, HPE_INVALID_METHOD);
+#endif
   }
 
   // illegal header field name line folding


### PR DESCRIPTION
This change adds non-standard HTTP method support.  We added new
callback on_method of type http_data_cb, which notifies incoming
method.  For non-standard HTTP method, method field in struct
http_parser becomes HTTP_METHOD_UNKNOWN.

The non-standard HTTP method is disabled by default, and must be
explicitly enabled by giving -DHTTP_PARSER_METHOD_CB=1 on build time.
This is for backward compatibility; because non-standard HTTP method
is now accepted rather than rejected.
