### PR TITLE
Makefile: cleanup install, uninstall, clean, all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
   - gcc
 
 script:
-  - "make"
+  - make test
 
 notifications:
   email: false


### PR DESCRIPTION
Lots of little Makefile changes in here. (also, happens to include the changes in #243 and #264)
If any of these changes are not desired, I'm happy to revise with them omitted.

---

install now works on OS X in addition to Linux ("install -D" not supported on OS X)

also installs the static library

shared and static libraries are not rebuilt if no sources changed
(the files are now "targets" in the Makefile)
(so that "make && sudo make install" does not re-build the libs under sudo)

Make DESTDIR and PREFIX work together. They are usually both specified
to a typical configure / make system. Usually you would do something
like "./configure --prefix=/usr && make DESTDIR=tmp/pkg install".
Before this change, specifying PREFIX would cause DESTDIR to be ignored
(you would have to incorporate your intended DESTDIR into PREFIX,
which is surprising).

small fixups for uninstall and clean

new default "all" target that does not run tests
(run "make test" for previous default behavior)
