### PR TITLE
simplify parsing M-SEARCH method, group P methods

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1007,7 +1007,7 @@ reexecute:
           UPDATE_STATE(s_req_spaces_before_url);
         } else if (ch == matcher[parser->index]) {
           ; /* nada */
-        } else if (IS_ALPHA(ch)) {
+        } else if ((ch >= 'A' && ch <= 'Z') || ch == '-') {
 
           switch (parser->method << 16 | parser->index << 8 | ch) {
 #define XX(meth, pos, ch, new_meth) \
@@ -1016,31 +1016,27 @@ reexecute:
 
             XX(POST,      1, 'U', PUT)
             XX(POST,      1, 'A', PATCH)
+            XX(POST,      1, 'R', PROPFIND)
+            XX(PUT,       2, 'R', PURGE)
             XX(CONNECT,   1, 'H', CHECKOUT)
             XX(CONNECT,   2, 'P', COPY)
             XX(MKCOL,     1, 'O', MOVE)
             XX(MKCOL,     1, 'E', MERGE)
+            XX(MKCOL,     1, '-', MSEARCH)
             XX(MKCOL,     2, 'A', MKACTIVITY)
             XX(MKCOL,     3, 'A', MKCALENDAR)
             XX(SUBSCRIBE, 1, 'E', SEARCH)
             XX(REPORT,    2, 'B', REBIND)
-            XX(POST,      1, 'R', PROPFIND)
             XX(PROPFIND,  4, 'P', PROPPATCH)
-            XX(PUT,       2, 'R', PURGE)
             XX(LOCK,      1, 'I', LINK)
             XX(UNLOCK,    2, 'S', UNSUBSCRIBE)
             XX(UNLOCK,    2, 'B', UNBIND)
             XX(UNLOCK,    3, 'I', UNLINK)
 #undef XX
-
             default:
               SET_ERRNO(HPE_INVALID_METHOD);
               goto error;
           }
-        } else if (ch == '-' &&
-                   parser->index == 1 &&
-                   parser->method == HTTP_MKCOL) {
-          parser->method = HTTP_MSEARCH;
         } else {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;


### PR DESCRIPTION
This just makes the method verb parsing code a bit more elegant:
- can use same switch-lookup for `-` char case for `M-SEARCH`
- move PROPFIND and PURGE to be next to the other P methods

also, change IS_ALPHA(ch) to just A <= ch <= Z
(very slight optimization, only uppercase will match in switch)

I tested with `./bench` on OS X and in a Linux VM, and performance is pretty much the same with this change, just an insignificant smidge faster. I tested branches in back/forth/back/forth pattern.

```
OS X,     master     :  830174.250000 req/sec,  829930.875000 req/sec
OS X,     this branch:  841326.375000 req/sec,  836593.812500 req/sec

Linux VM, master     : 1164776.500000 req/sec, 1165652.750000 req/sec
Linux VM, this branch: 1179126.250000 req/sec, 1175704.875000 req/sec
```

But this isn't about the performance, just mostly about getting rid of the extra if statement just for the `M-Search` method.
