### PR TITLE
Fix Content-Length header parsing.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1366,12 +1366,7 @@ reexecute:
                   || c != CONTENT_LENGTH[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CONTENT_LENGTH)-2) {
-                if (parser->flags & F_CONTENTLENGTH) {
-                  SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
-                  goto error;
-                }
                 parser->header_state = h_content_length;
-                parser->flags |= F_CONTENTLENGTH;
               }
               break;
 
@@ -1474,6 +1469,12 @@ reexecute:
               goto error;
             }
 
+            if (parser->flags & F_CONTENTLENGTH) {
+              SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+              goto error;
+            }
+
+            parser->flags |= F_CONTENTLENGTH;
             parser->content_length = ch - '0';
             break;
 

--- a/http_parser.h
+++ b/http_parser.h
@@ -27,7 +27,7 @@ extern "C" {
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
 #define HTTP_PARSER_VERSION_MINOR 7
-#define HTTP_PARSER_VERSION_PATCH 0
+#define HTTP_PARSER_VERSION_PATCH 1
 
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && \

--- a/test.c
+++ b/test.c
@@ -1745,6 +1745,32 @@ const struct message responses[] =
   ,.body= ""
   }
 
+#define CONTENT_LENGTH_X 21
+, {.name= "Content-Length-X"
+  ,.type= HTTP_RESPONSE
+  ,.raw= "HTTP/1.1 200 OK\r\n"
+         "Content-Length-X: 0\r\n"
+         "Transfer-Encoding: chunked\r\n"
+         "\r\n"
+         "2\r\n"
+         "OK\r\n"
+         "0\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.status_code= 200
+  ,.response_status= "OK"
+  ,.num_headers= 2
+  ,.headers= { { "Content-Length-X", "0" }
+             , { "Transfer-Encoding", "chunked" }
+             }
+  ,.body= "OK"
+  ,.num_chunks_complete= 2
+  ,.chunk_lengths= { 2 }
+  }
+
 , {.name= NULL } /* sentinel */
 };
 


### PR DESCRIPTION
Commit e2e467b ("Update http-parser to 2.6.1") enforces that messages
contain no more than one Content-Length header but it considers any
header that starts with "Content-Length" as a duplicate.

Fixes: https://github.com/nodejs/http-parser/issues/324

R=@jasnell