### PR TITLE
add settings flags, refactor lenient_http_headers setting

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -645,7 +645,8 @@ size_t http_parser_execute (http_parser *parser,
   const char *body_mark = 0;
   const char *status_mark = 0;
   enum state p_state = (enum state) parser->state;
-  const unsigned int lenient = parser->lenient_http_headers;
+  const unsigned int lenient =
+    (settings->flags & SETTINGS_FLAG_LENIENT_HTTP_HEADERS);
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {

--- a/http_parser.h
+++ b/http_parser.h
@@ -218,6 +218,10 @@ enum http_errno {
 /* Get an http_errno value from an http_parser */
 #define HTTP_PARSER_ERRNO(p)            ((enum http_errno) (p)->http_errno)
 
+enum http_parser_settings_flags {
+  SETTINGS_FLAG_DEFAULT = 0,
+  SETTINGS_FLAG_LENIENT_HTTP_HEADERS = 1
+};
 
 struct http_parser {
   /** PRIVATE **/
@@ -226,7 +230,6 @@ struct http_parser {
   unsigned int state : 7;        /* enum state from http_parser.c */
   unsigned int header_state : 7; /* enum header_state from http_parser.c */
   unsigned int index : 7;        /* index into current matcher */
-  unsigned int lenient_http_headers : 1;
 
   uint32_t nread;          /* # bytes read in various scenarios */
   uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
@@ -264,6 +267,7 @@ struct http_parser_settings {
    */
   http_cb      on_chunk_header;
   http_cb      on_chunk_complete;
+  uint32_t     flags;
 };
 
 


### PR DESCRIPTION
A previous change during a security fix added the ability to set a `lenient_http_headers` flag on the HTTP Parser instance. The way it was done was a bit of a hack at the time in order to avoid an ABI breaking change. This PR adds a new `uint32_t` flags field to `http_parser_settings` in order to provide a more robust and correct way of passing these kinds of settings into a parser instance.

_Note_: This is an ABI change so it would require a semver-major bump

/cc @indutny 
