### PR TITLE
header: remove unneeded symbols from headers

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -173,7 +173,7 @@ do {                                                                 \
 
 static const char *method_strings[] =
   {
-#define XX(num, name, string) #string,
+#define XX(num, string) #string,
   HTTP_METHOD_MAP(XX)
 #undef XX
   };

--- a/http_parser.h
+++ b/http_parser.h
@@ -92,50 +92,50 @@ typedef int (*http_cb) (http_parser*);
 
 /* Request Methods */
 #define HTTP_METHOD_MAP(XX)         \
-  XX(0,  DELETE,      DELETE)       \
-  XX(1,  GET,         GET)          \
-  XX(2,  HEAD,        HEAD)         \
-  XX(3,  POST,        POST)         \
-  XX(4,  PUT,         PUT)          \
+  XX(0,  DELETE)                    \
+  XX(1,  GET)                       \
+  XX(2,  HEAD)                      \
+  XX(3,  POST)                      \
+  XX(4,  PUT)                       \
   /* pathological */                \
-  XX(5,  CONNECT,     CONNECT)      \
-  XX(6,  OPTIONS,     OPTIONS)      \
-  XX(7,  TRACE,       TRACE)        \
+  XX(5,  CONNECT)                   \
+  XX(6,  OPTIONS)                   \
+  XX(7,  TRACE)                     \
   /* WebDAV */                      \
-  XX(8,  COPY,        COPY)         \
-  XX(9,  LOCK,        LOCK)         \
-  XX(10, MKCOL,       MKCOL)        \
-  XX(11, MOVE,        MOVE)         \
-  XX(12, PROPFIND,    PROPFIND)     \
-  XX(13, PROPPATCH,   PROPPATCH)    \
-  XX(14, SEARCH,      SEARCH)       \
-  XX(15, UNLOCK,      UNLOCK)       \
-  XX(16, BIND,        BIND)         \
-  XX(17, REBIND,      REBIND)       \
-  XX(18, UNBIND,      UNBIND)       \
-  XX(19, ACL,         ACL)          \
+  XX(8,  COPY)                      \
+  XX(9,  LOCK)                      \
+  XX(10, MKCOL)                     \
+  XX(11, MOVE)                      \
+  XX(12, PROPFIND)                  \
+  XX(13, PROPPATCH)                 \
+  XX(14, SEARCH)                    \
+  XX(15, UNLOCK)                    \
+  XX(16, BIND)                      \
+  XX(17, REBIND)                    \
+  XX(18, UNBIND)                    \
+  XX(19, ACL)                       \
   /* subversion */                  \
-  XX(20, REPORT,      REPORT)       \
-  XX(21, MKACTIVITY,  MKACTIVITY)   \
-  XX(22, CHECKOUT,    CHECKOUT)     \
-  XX(23, MERGE,       MERGE)        \
+  XX(20, REPORT)                    \
+  XX(21, MKACTIVITY)                \
+  XX(22, CHECKOUT)                  \
+  XX(23, MERGE)                     \
   /* upnp */                        \
-  XX(24, MSEARCH,     M-SEARCH)     \
-  XX(25, NOTIFY,      NOTIFY)       \
-  XX(26, SUBSCRIBE,   SUBSCRIBE)    \
-  XX(27, UNSUBSCRIBE, UNSUBSCRIBE)  \
+  XX(24, MSEARCH)                   \
+  XX(25, NOTIFY)                    \
+  XX(26, SUBSCRIBE)                 \
+  XX(27, UNSUBSCRIBE)               \
   /* RFC-5789 */                    \
-  XX(28, PATCH,       PATCH)        \
-  XX(29, PURGE,       PURGE)        \
+  XX(28, PATCH)                     \
+  XX(29, PURGE)                     \
   /* CalDAV */                      \
-  XX(30, MKCALENDAR,  MKCALENDAR)   \
+  XX(30, MKCALENDAR)                \
   /* RFC-2068, section 19.6.1.2 */  \
-  XX(31, LINK,        LINK)         \
-  XX(32, UNLINK,      UNLINK)       \
+  XX(31, LINK)                      \
+  XX(32, UNLINK)                    \
 
 enum http_method
   {
-#define XX(num, name, string) HTTP_##name = num,
+#define XX(num, name) HTTP_##name = num,
   HTTP_METHOD_MAP(XX)
 #undef XX
   };


### PR DESCRIPTION
Because the name and string in `HTTP_METHOD_MAP` are 100% similar, so merge them into one symbol and update `XX`s.

R= @bnoordhuis 