### PR TITLE
Various optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,18 +70,25 @@ ifneq (darwin,$(PLATFORM))
 LDFLAGS_LIB += -Wl,-soname=$(SONAME)
 endif
 
-test: test_g test_fast
+test: test_g test_fast test_g_no_intrisics
 	$(HELPER) ./test_g$(BINEXT)
 	$(HELPER) ./test_fast$(BINEXT)
+	$(HELPER) ./test_g_no_intrisics$(BINEXT)
+
+http_parser_g_no_intrisics.o: http_parser.c http_parser.h Makefile
+	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) -DUSE_INTRISICS_CRLF=0 -c http_parser.c -o $@
 
 test_g: http_parser_g.o test_g.o
 	$(CC) $(CFLAGS_DEBUG) $(LDFLAGS) http_parser_g.o test_g.o -o $@
+
+test_g_no_intrisics: http_parser_g_no_intrisics.o test_g.o
+	$(CC) $(CFLAGS_DEBUG) $(LDFLAGS) http_parser_g_no_intrisics.o test_g.o -o $@
 
 test_g.o: test.c http_parser.h Makefile
 	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) -c test.c -o $@
 
 http_parser_g.o: http_parser.c http_parser.h Makefile
-	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) -c http_parser.c -o $@
+	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) -DUSE_INTRISICS_CRLF=1 -c http_parser.c -o $@
 
 test_fast: http_parser.o test.o http_parser.h
 	$(CC) $(CFLAGS_FAST) $(LDFLAGS) http_parser.o test.o -o $@
@@ -146,7 +153,7 @@ uninstall:
 	rm $(LIBDIR)/libhttp_parser.so
 
 clean:
-	rm -f *.o *.a tags test test_fast test_g \
+	rm -f *.o *.a tags test test_fast test_g test_g_no_intrisics \
 		http_parser.tar libhttp_parser.so.* \
 		url_parser url_parser_g parsertrace parsertrace_g \
 		*.exe *.exe.so

--- a/http_parser.c
+++ b/http_parser.c
@@ -495,6 +495,8 @@ int http_message_needs_eof(const http_parser *parser);
 # if defined(_MSC_VER) || \
     (defined(__SSE2__) && defined(__GNUC__))
 #   define USE_INTRISICS_CRLF 1
+# else
+#   define USE_INTRISICS_CRLF 0
 # endif
 #endif
 
@@ -520,14 +522,14 @@ const char* find_crlf(const char* p, const char* data, size_t len) {
   uint32_t result = 0;
 
   while ((uintptr_t)p & 15 && p <= lastp) {
-    if ( *p == CR || *p == LF ) {
+    if (*p == CR || *p == LF) {
       return p;
     }
     ++p;
   }
-  if ( lastp - p < 32 ) {
+  if (lastp - p < 32) {
     while (p <= lastp) {
-      if ( *p == CR || *p == LF ) {
+      if (*p == CR || *p == LF) {
         return p;
       }
       ++p;
@@ -544,7 +546,7 @@ const char* find_crlf(const char* p, const char* data, size_t len) {
     }
     if (!result) {
       while (p <= lastp) {
-        if ( *p == CR || *p == LF ) {
+        if (*p == CR || *p == LF) {
           return p;
         }
         ++p;

--- a/http_parser.c
+++ b/http_parser.c
@@ -481,14 +481,14 @@ static struct {
 
 int http_message_needs_eof(const http_parser *parser);
 
-const char* findCRLF(const char* p, const char* data, size_t len);
+const char* find_crlf(const char* p, const char* data, size_t len);
 
 
 #if defined(__SSE2__) && defined(__GNUC__) 
 
 #include <emmintrin.h>
 
-const char* findCRLF(const char* p, const char* data, size_t len) {
+const char* find_crlf(const char* p, const char* data, size_t len) {
   const char* lastp = MIN(data+len, HTTP_MAX_HEADER_SIZE+p);
 
   int32_t result = 0;
@@ -539,7 +539,7 @@ const char* findCRLF(const char* p, const char* data, size_t len) {
 
 #else
 
-const char* findCRLF(const char* p, const char* data, size_t len) {
+const char* find_crlf(const char* p, const char* data, size_t len) {
   const char* p_cr;
   const char* p_lf;
   size_t limit = data + len - p;
@@ -1322,7 +1322,7 @@ reexecute:
       case s_header_field:
       {
         const char* start = p;
-HEADER_FIELD_BEGIN:
+header_field_begin:
         if ( parser->header_state == h_general ) {
           for (; p != data + len; p++) {
             ch = *p;
@@ -1342,7 +1342,7 @@ HEADER_FIELD_BEGIN:
             switch (parser->header_state) {
               case h_general:
                 --p;
-                goto HEADER_FIELD_BEGIN;
+                goto header_field_begin;
                 break;
 
               case h_C:
@@ -1570,7 +1570,7 @@ HEADER_FIELD_BEGIN:
           switch (h_state) {
             case h_general:
             {
-              p = findCRLF(p, data, len);
+              p = find_crlf(p, data, len);
               --p;
 
               break;

--- a/http_parser.c
+++ b/http_parser.c
@@ -492,7 +492,11 @@ const char* find_crlf(const char* p, const char* data, size_t len);
 #include <emmintrin.h>
 #endif
 
-#if defined(_MSC_VER) || (defined(__SSE2__) && defined(__GNUC__))
+#ifndef USE_INTRISICS_CRLF
+# define USE_INTRISICS_CRLF defined(_MSC_VER) || (defined(__SSE2__) && defined(__GNUC__))
+#endif
+
+#if USE_INTRISICS_CRLF
 
 int32_t get_crlf_mask(const char* p) {
   /* [ c, 0, 0, 0, 0, 0 .. 0 ] */
@@ -523,7 +527,7 @@ const char* find_crlf(const char* p, const char* data, size_t len) {
   if (!result) {
     while(!result && lastp >= p+32) {
       p += 32;
-	  result = get_crlf_mask(p + 16) << 16 | get_crlf_mask(p);
+      result = get_crlf_mask(p + 16) << 16 | get_crlf_mask(p);
     }
     if (!result) {
       return data + len;

--- a/http_parser.c
+++ b/http_parser.c
@@ -22,6 +22,7 @@
  * IN THE SOFTWARE.
  */
 #include "http_parser.h"
+#include "http_parser_internal.h"
 #include <assert.h>
 #include <stddef.h>
 #include <ctype.h>
@@ -483,8 +484,6 @@ static struct {
 
 int http_message_needs_eof(const http_parser *parser);
 
-static const char* find_crlf(const char* p, const char* data, size_t len);
-
 #if defined(_MSC_VER) // SSE2 is baseline
 #include <intrin.h>
 #define __builtin_ctz _tzcnt_u32
@@ -516,7 +515,7 @@ static uint32_t get_crlf_mask(const char* p) {
   return _mm_movemask_epi8(v2);
 }
 
-static const char* find_crlf(const char* p, const char* data, size_t len) {
+const char* find_crlf(const char* p, const char* data, size_t len) {
   const char* lastp = MIN(data + len, HTTP_MAX_HEADER_SIZE + p);
   uint32_t result = 0;
 
@@ -562,7 +561,7 @@ static const char* find_crlf(const char* p, const char* data, size_t len) {
 
 #else
 
-static const char* find_crlf(const char* p, const char* data, size_t len) {
+const char* find_crlf(const char* p, const char* data, size_t len) {
   const char* p_cr;
   const char* p_lf;
   size_t limit = data + len - p;

--- a/http_parser.c
+++ b/http_parser.c
@@ -444,7 +444,7 @@ enum http_host_state
     }                                                         \
     ch = *++p;                                                \
     ++parser->nread;                                          \
-  } else                                                      \
+  } else {}                                                   \
 
 
 /**

--- a/http_parser.c
+++ b/http_parser.c
@@ -500,10 +500,10 @@ const char* find_crlf(const char* p, const char* data, size_t len);
 
 int32_t get_crlf_mask(const char* p) {
   /* [ c, 0, 0, 0, 0, 0 .. 0 ] */
-  const __m128i vCR = _mm_set1_epi8(0x0a);
+  const __m128i vCR = _mm_set1_epi8(0x0d);
 
   /* [ c, 0, 0, 0, 0, 0 .. 0 ] */
-  const __m128i vLF = _mm_set1_epi8(0x0d);
+  const __m128i vLF = _mm_set1_epi8(0x0a);
 
   __m128i v1, v2;
   v1 = *(__m128i*)p;

--- a/http_parser.c
+++ b/http_parser.c
@@ -484,14 +484,14 @@ int http_message_needs_eof(const http_parser *parser);
 const char* findCRLF(const char* p, const char* data, size_t len);
 
 
-#ifdef __SSE2__ 
+#if defined(__SSE2__) && defined(__GNUC__) 
 
 #include <emmintrin.h>
 
 const char* findCRLF(const char* p, const char* data, size_t len) {
   const char* lastp = MIN(data+len, HTTP_MAX_HEADER_SIZE+p);
 
-  long result = 0;
+  int32_t result = 0;
   __m128i v1, v2;
   __m128i vCR = _mm_set_epi32(0x0a0a0a0a, 0x0a0a0a0a,0x0a0a0a0a, 0x0a0a0a0a); // [ c, 0, 0, 0, 0, 0 .. 0 ]
 

--- a/http_parser.c
+++ b/http_parser.c
@@ -435,6 +435,15 @@ enum http_host_state
   (IS_ALPHANUM(c) || (c) == '.' || (c) == '-' || (c) == '_')
 #endif
 
+#define NEXTHEADERCHAR() \
+  if (UNLIKELY(p+1 == (data+len))) {                          \
+    COUNT_HEADER_SIZE(0);                                     \
+    break;                                                    \
+  }                                                           \
+  ch = *++p;                                                  \
+  ++parser->nread;
+
+
 /**
  * Verify that a char is a valid visible (printable) US-ASCII
  * character or %x80-FF
@@ -781,17 +790,17 @@ reexecute:
       case s_res_H:
         STRICT_CHECK(ch != 'T');
         UPDATE_STATE(s_res_HT);
-        break;
+        NEXTHEADERCHAR();
 
       case s_res_HT:
         STRICT_CHECK(ch != 'T');
         UPDATE_STATE(s_res_HTT);
-        break;
+        NEXTHEADERCHAR();
 
       case s_res_HTT:
         STRICT_CHECK(ch != 'P');
         UPDATE_STATE(s_res_HTTP);
-        break;
+        NEXTHEADERCHAR();
 
       case s_res_HTTP:
         STRICT_CHECK(ch != '/');
@@ -1101,17 +1110,17 @@ reexecute:
       case s_req_http_H:
         STRICT_CHECK(ch != 'T');
         UPDATE_STATE(s_req_http_HT);
-        break;
+        NEXTHEADERCHAR();
 
       case s_req_http_HT:
         STRICT_CHECK(ch != 'T');
         UPDATE_STATE(s_req_http_HTT);
-        break;
+        NEXTHEADERCHAR();
 
       case s_req_http_HTT:
         STRICT_CHECK(ch != 'P');
         UPDATE_STATE(s_req_http_HTTP);
-        break;
+        NEXTHEADERCHAR();
 
       case s_req_http_HTTP:
         STRICT_CHECK(ch != '/');
@@ -1225,7 +1234,7 @@ reexecute:
             parser->header_state = h_general;
             break;
         }
-        break;
+        NEXTHEADERCHAR();
       }
 
       case s_header_field:

--- a/http_parser_internal.h
+++ b/http_parser_internal.h
@@ -1,0 +1,29 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef http_parser_internal_h
+#define http_parser_internal_h
+
+#include <stddef.h>
+
+const char* find_crlf(const char* p, const char* data, size_t len);
+
+#endif
+

--- a/test.c
+++ b/test.c
@@ -3389,14 +3389,14 @@ struct find_crlf_test {
 
 const struct find_crlf_test find_crlf_tests[] =
 { {.name="long string without crlf"
-  ,.p="                                                "  /* 16*3 */
+  ,.p="                                                "
   ,.offset=0
   ,.len=48
   ,.should_find=0
   ,.position=0
   }
   ,{.name="long string with crlf"
-  ,.p="                                               \n"  /* 16*3 */
+  ,.p="                                               \n"
   ,.offset=0
   ,.len=48
   ,.should_find=1
@@ -3417,14 +3417,14 @@ const struct find_crlf_test find_crlf_tests[] =
   ,.position=2
   }
   ,{.name="long string without crlf with offset"
-  ,.p="                                                "  /* 16*3 */
+  ,.p="                                                "
   ,.offset=3
   ,.len=48
   ,.should_find=0
   ,.position=0
   }
   ,{.name="long string with crlf with offset"
-  ,.p="                                               \n"  /* 16*3 */
+  ,.p="                                               \n"
   ,.offset=3
   ,.len=48
   ,.should_find=1
@@ -3438,21 +3438,21 @@ const struct find_crlf_test find_crlf_tests[] =
   ,.position=0
   }
   ,{.name="short string with crlf with offset"
-  ,.p="  \n"  /* 16*3 */
+  ,.p="  \n"
   ,.offset=2
   ,.len=3
   ,.should_find=1
   ,.position=2
   }
   ,{.name="string with crlf before and after offset"
-  ,.p="\r\n                                             \n"  /* 16*3 */
+  ,.p="\r\n                                             \n"
   ,.offset=3
   ,.len=48
   ,.should_find=1
   ,.position=47
   }
   ,{.name="string with crlf before offset and after max position"
-  ,.p="\r\n                                             \n"  /* 16*3 */
+  ,.p="\r\n                                             \n"
   ,.offset=3
   ,.len=30
   ,.should_find=0
@@ -3486,12 +3486,12 @@ test_find_crlf (void)
     const char* n = find_crlf(test->p + test->offset, test->p, test->len);
     if (!test->should_find) {
       if (n != test->p + test->len) {
-        printf("test_find_crlf(%s) should not find any crlf\n", test->name);
-        printf("test should end at %d instead it is at %ld\n", test->len, n - test->p);
+        printf("\n***test_find_crlf(%s) should not find any crlf\n", test->name);
+        printf("\n***test should end at %d instead it is at %ld\n", test->len, n - test->p);
         abort();
       }
-    } else if (n != test->p + test->position){
-      printf("test_find_crlf(%s) should find crlf at(%d) instead of (%ld)\n", test->name, test->position, n-test->p);
+    } else if (n != test->p + test->position) {
+      printf("\n***test_find_crlf(%s) should find crlf at(%d) instead of (%ld)\n", test->name, test->position, n-test->p);
       abort();
     }
   }

--- a/test.c
+++ b/test.c
@@ -3458,6 +3458,20 @@ const struct find_crlf_test find_crlf_tests[] =
   ,.should_find=0
   ,.position=0
   }
+  ,{.name="string with crlf"
+  ,.p="      \r\n"
+  ,.offset=0
+  ,.len=8
+  ,.should_find=1
+  ,.position=6
+  }
+  ,{.name="string with crlf"
+  ,.p="      \n\r"
+  ,.offset=0
+  ,.len=8
+  ,.should_find=1
+  ,.position=6
+  }
 
 };
 


### PR DESCRIPTION
Hi, basically I was just messing around and did some benchmarking, found some interesting things, so I made some changes. Mostly to do with removing some of the branches and created a SIMD version of finding CRLF that doesn't need to walk the whole payload twice(worst case)

Below are the benchmark results
### OSX (el capitan, mbp 13" early 2015, 3.1 GHz Intel Core i7)
#### Clang

| time(master) | req/s(master) | time(new) | req/s(new) | percent |
| --- | --- | --- | --- | --- |
| 5.761632 | 867809.687500 | 5.104409 | 979545.312500 | 11.4069 |
| 5.769115 | 866684.062500 | 5.104001 | 979623.625000 | 11.5289 |
| 5.803461 | 861554.875000 | 5.086198 | 983052.625000 | 12.3592 |
| 5.779534 | 865121.687500 | 5.082990 | 983672.937500 | 12.0519 |
| 5.762670 | 867653.375000 | 5.092542 | 981827.875000 | 11.6288 |
#### GCC 4.9

| time(master) | req/s(master) | time(new) | req/s(new) | percent |
| --- | --- | --- | --- | --- |
| 4.297466 | 1163476.375000 | 3.787979 | 1319965.000000 | 11.8555 |
| 4.159397 | 1202097.250000 | 3.774015 | 1324849.000000 | 9.26533 |
| 4.230322 | 1181943.125000 | 3.788900 | 1319644.250000 | 10.4347 |
| 4.214539 | 1186369.375000 | 3.772407 | 1325413.750000 | 10.4906 |
| 4.162938 | 1201074.750000 | 3.763118 | 1328685.375000 | 9.6042 |
### ubuntu 14.04 ( Intel Core i7-6700 @ 3.40GHz )

| time(master) | req/s(master) | time(new) | req/s(new) | percent |
| --- | --- | --- | --- | --- |
| 3.186016 | 1569358.000000 | 2.815905 | 1775628.000000 | 11.6167 |
| 3.186449 | 1569144.875000 | 2.846761 | 1756382.125000 | 10.6604 |
| 3.190864 | 1566973.625000 | 2.877822 | 1737425.125000 | 9.81057 |
| 3.183230 | 1570731.625000 | 2.813425 | 1777193.250000 | 11.6173 |
| 3.190520 | 1567142.625000 | 2.849443 | 1754728.875000 | 10.6903 |
