### PR TITLE
parser: fix handling of newlines before HTTP responses

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -757,16 +757,14 @@ reexecute:
 
       case s_start_res:
       {
+        if (ch == CR || ch == LF)
+          break;
         parser->flags = 0;
         parser->content_length = ULLONG_MAX;
 
         switch (ch) {
           case 'H':
             UPDATE_STATE(s_res_H);
-            break;
-
-          case CR:
-          case LF:
             break;
 
           default:

--- a/test.c
+++ b/test.c
@@ -3891,6 +3891,39 @@ test_message_connect (const struct message *msg)
   parser_free();
 }
 
+/* Verify that `on_message_begin` callback isn't called until the first
+ * byte of message's start line is received. */
+void
+test_message_empty_prefix_lines (enum http_parser_type type)
+{
+  parser_init(type);
+
+  const char* parser_type = type == HTTP_REQUEST ? "request" :
+    (type == HTTP_RESPONSE ? "response" : "both");
+
+  const char *empty_lines = "\r\n\r\r\r\n";
+  parse(empty_lines, strlen(empty_lines));
+
+  if (messages[0].message_begin_cb_called) {
+    fprintf(stderr, "\n*** message_begin callback was called after "
+            "empty prefix lines, parser type '%s' ***\n\n", parser_type);
+    abort();
+  }
+
+  // NOTE: We use 'H' as the first message's byte as it's suitable for
+  // both request's and response's start lines.
+  parse("H", 1);
+
+  if (!messages[0].message_begin_cb_called) {
+    fprintf(stderr, "\n*** message_begin callback was not called after the "
+            "first message byte was received, parser type '%s' ***\n\n",
+            parser_type);
+    abort();
+  }
+
+  parser_free();
+}
+
 int
 main (void)
 {
@@ -3918,6 +3951,9 @@ main (void)
   test_preserve_data();
   test_parse_url();
   test_method_str();
+  test_message_empty_prefix_lines(HTTP_REQUEST);
+  test_message_empty_prefix_lines(HTTP_RESPONSE);
+  test_message_empty_prefix_lines(HTTP_BOTH);
 
   //// NREAD
   test_header_nread_value();


### PR DESCRIPTION
This diff fixes ignoring of CR and LF chars received before HTTP response's start line the same way as they are handled with HTTP_REQUEST and HTTP_BOTH parser types.