### PR TITLE
Unbreak `make install` in BSDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,18 @@ parsertrace_g: http_parser_g.o contrib/parsertrace.c
 tags: http_parser.c http_parser.h test.c
 	ctags $^
 
-install: library
-	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
+install-dirs:
+	mkdir -p $(INCLUDEDIR)
+	mkdir -p $(LIBDIR)
+
+install: library install-dirs
+	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
+	$(INSTALL) $(SONAME) $(LIBDIR)/$(SONAME)
 	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
 
-install-strip: library
-	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
+install-strip: library install-dirs
+	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
+	$(INSTALL) -s $(SONAME) $(LIBDIR)/$(SONAME)
 	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,12 @@ install-dirs:
 install: library install-dirs
 	$(INSTALL) http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 	$(INSTALL) $(SONAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(DESTDIR)$(LIBDIR)/libhttp_parser.$(SOEXT)
+	ln -s $(SONAME) $(DESTDIR)$(LIBDIR)/libhttp_parser.$(SOEXT)
 
 install-strip: library install-dirs
 	$(INSTALL) http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -s $(SONAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(DESTDIR)$(LIBDIR)/libhttp_parser.$(SOEXT)
+	ln -s $(SONAME) $(DESTDIR)$(LIBDIR)/libhttp_parser.$(SOEXT)
 
 uninstall:
 	rm $(DESTDIR)$(INCLUDEDIR)/http_parser.h

--- a/Makefile
+++ b/Makefile
@@ -123,23 +123,23 @@ tags: http_parser.c http_parser.h test.c
 	ctags $^
 
 install-dirs:
-	mkdir -p $(INCLUDEDIR)
-	mkdir -p $(LIBDIR)
+	mkdir -p $(DESTDIR)$(INCLUDEDIR)
+	mkdir -p $(DESTDIR)$(LIBDIR)
 
 install: library install-dirs
-	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+	$(INSTALL) http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+	$(INSTALL) $(SONAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -s $(LIBDIR)/$(SONAME) $(DESTDIR)$(LIBDIR)/libhttp_parser.$(SOEXT)
 
 install-strip: library install-dirs
-	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) -s $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+	$(INSTALL) http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+	$(INSTALL) -s $(SONAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -s $(LIBDIR)/$(SONAME) $(DESTDIR)$(LIBDIR)/libhttp_parser.$(SOEXT)
 
 uninstall:
-	rm $(INCLUDEDIR)/http_parser.h
-	rm $(LIBDIR)/$(SONAME)
-	rm $(LIBDIR)/libhttp_parser.so
+	rm $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+	rm $(DESTDIR)$(LIBDIR)/$(SONAME)
+	rm $(DESTDIR)$(LIBDIR)/libhttp_parser.so
 
 clean:
 	rm -f *.o *.a tags test test_fast test_g \


### PR DESCRIPTION
I've only tested this in freebsd-12.0 where the changes get me from syntax errors in the Makefile to passing `port test` with flying colors.