### PR TITLE
Fix FALLTHROUGH warning in switch of GCC7

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1816,6 +1816,7 @@ reexecute:
             case 2:
               parser->upgrade = 1;
 
+            /* FALLTHROUGH */
             case 1:
               parser->flags |= F_SKIPBODY;
               break;
@@ -2375,7 +2376,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       case s_req_server_with_at:
         found_at = 1;
 
-      /* FALLTROUGH */
+      /* FALLTHROUGH */
       case s_req_server:
         uf = UF_HOST;
         break;


### PR DESCRIPTION
See -Wimplicit-fallthrough in https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html