### PR TITLE
Tolerate non-compliant status line responses

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -863,10 +863,9 @@ reexecute:
               UPDATE_STATE(s_res_status_start);
               break;
             case CR:
-              UPDATE_STATE(s_res_line_almost_done);
-              break;
             case LF:
-              UPDATE_STATE(s_header_field_start);
+              UPDATE_STATE(s_res_status_start);
+              REEXECUTE();
               break;
             default:
               SET_ERRNO(HPE_INVALID_STATUS);
@@ -888,19 +887,13 @@ reexecute:
 
       case s_res_status_start:
       {
-        if (ch == CR) {
-          UPDATE_STATE(s_res_line_almost_done);
-          break;
-        }
-
-        if (ch == LF) {
-          UPDATE_STATE(s_header_field_start);
-          break;
-        }
-
         MARK(status);
         UPDATE_STATE(s_res_status);
         parser->index = 0;
+
+        if (ch == CR || ch == LF)
+            REEXECUTE();
+
         break;
       }
 

--- a/http_parser.c
+++ b/http_parser.c
@@ -892,7 +892,7 @@ reexecute:
         parser->index = 0;
 
         if (ch == CR || ch == LF)
-            REEXECUTE();
+          REEXECUTE();
 
         break;
       }

--- a/test.c
+++ b/test.c
@@ -78,6 +78,7 @@ struct message {
   int message_begin_cb_called;
   int headers_complete_cb_called;
   int message_complete_cb_called;
+  int status_cb_called;
   int message_complete_on_eof;
   int body_is_final;
 };
@@ -1981,6 +1982,9 @@ int
 response_status_cb (http_parser *p, const char *buf, size_t len)
 {
   assert(p == parser);
+
+  messages[num_messages].status_cb_called = TRUE;
+
   strlncat(messages[num_messages].response_status,
            sizeof(messages[num_messages].response_status),
            buf,
@@ -2405,6 +2409,7 @@ message_eq (int index, int connect, const struct message *expected)
   } else {
     MESSAGE_CHECK_NUM_EQ(expected, m, status_code);
     MESSAGE_CHECK_STR_EQ(expected, m, response_status);
+    assert(m->status_cb_called);
   }
 
   if (!connect) {


### PR DESCRIPTION
- original fix is from daeon: https://github.com/daeon/http-parser/

  "Tolerate web servers which do not return a status message in the
   return response.

   I have noticed this usse on several websites such downloads from
   mediafire.com"

- original pull request: https://github.com/nodejs/http-parser/pull/254
- i merely added the status_cb_called unit test check, there already
  is a test that triggers this without the patch (a 301 without a
  reason phrase).