### PR TITLE
ignore headers transfer_encoding_chunked and content_length to work with http assemblers.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1783,7 +1783,6 @@ reexecute:
         STRICT_CHECK(ch != LF);
 
         parser->nread = 0;
-
         if ((settings->ignore_header_content_length != 0) &&
             (parser->flags & F_CONTENTLENGTH)) {
           parser->flags |= F_CONTENTLENGTH_IGNORED;

--- a/http_parser.c
+++ b/http_parser.c
@@ -1400,7 +1400,7 @@ reexecute:
 
           case h_transfer_encoding:
             /* looking for 'Transfer-Encoding: chunked' */
-            if ('c' == c) {
+            if ('c' == c && settings->ignore_header_transfer_encodig_chunked == 0) {
               parser->header_state = h_matching_transfer_encoding_chunked;
             } else {
               parser->header_state = h_general;
@@ -1783,6 +1783,10 @@ reexecute:
         STRICT_CHECK(ch != LF);
 
         parser->nread = 0;
+
+        if (settings->ignore_header_content_length == 0) {
+          parser->content_length = 0;
+        }
 
         hasBody = parser->flags & F_CHUNKED ||
           (parser->content_length > 0 && parser->content_length != ULLONG_MAX);

--- a/http_parser.c
+++ b/http_parser.c
@@ -1400,7 +1400,7 @@ reexecute:
 
           case h_transfer_encoding:
             /* looking for 'Transfer-Encoding: chunked' */
-            if ('c' == c && settings->ignore_header_transfer_encodig_chunked == 0) {
+            if ('c' == c && settings->ignore_header_transfer_encoding_chunked == 0) {
               parser->header_state = h_matching_transfer_encoding_chunked;
             } else {
               parser->header_state = h_general;

--- a/http_parser.h
+++ b/http_parser.h
@@ -224,6 +224,7 @@ enum flags
   , F_UPGRADE               = 1 << 5
   , F_SKIPBODY              = 1 << 6
   , F_CONTENTLENGTH         = 1 << 7
+  , F_CONTENTLENGTH_IGNORED = 1 << 8
   };
 
 
@@ -292,7 +293,7 @@ enum http_errno {
 struct http_parser {
   /** PRIVATE **/
   unsigned int type : 2;         /* enum http_parser_type */
-  unsigned int flags : 8;        /* F_* values from 'flags' enum; semi-public */
+  unsigned int flags : 9;        /* F_* values from 'flags' enum; semi-public */
   unsigned int state : 7;        /* enum state from http_parser.c */
   unsigned int header_state : 7; /* enum header_state from http_parser.c */
   unsigned int index : 7;        /* index into current matcher */

--- a/http_parser.h
+++ b/http_parser.h
@@ -336,7 +336,7 @@ struct http_parser_settings {
   http_cb      on_chunk_complete;
   /* Ignore chunked encoding, assume that body is assembled already
    */
-  int ignore_header_transfer_encodig_chunked;
+  int ignore_header_transfer_encoding_chunked;
   /* Ignore content length
    */
   int ignore_header_content_length;

--- a/http_parser.h
+++ b/http_parser.h
@@ -334,6 +334,12 @@ struct http_parser_settings {
    */
   http_cb      on_chunk_header;
   http_cb      on_chunk_complete;
+  /* Ignore chunked encoding, assume that body is assembled already
+   */
+  int ignore_header_transfer_encodig_chunked;
+  /* Ignore content length
+   */
+  int ignore_header_content_length;
 };
 
 


### PR DESCRIPTION
added ignore_header_transfer_encodig_chunked and ignore_header_content_length to settings.

ignore_header_content_length:
  useful if body length and content length does not match. happens with owa servers. or working with pre http assemblers that unzips compressed content without changing content-length.

ignore_header_transfer_encodig_chunked:
  useful when working with pre-http assemblers which assembles chunked content into one http packet without changing transfer-encoding field.

may be useful for someone.