### PR TITLE
add .deps and .dirstamp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ url_parser
 *.Makefile
 *.so
 *.a
+.deps
+.dirstamp

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ parsertrace_g
 *.sdf
 *.vsp
 *.psess
+.deps
+.dirstamp


### PR DESCRIPTION
I use http-parser in another project as a submodule. When I run autotools configure, it creates in the http-parser sub directory a directory and a file:

```
[user@localhost http-parser]$ git status
HEAD detached from 8d9e5db
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.deps/
	.dirstamp

nothing added to commit but untracked files present (use "git add" to track)
[user@localhost http-parser]$
```

It would be super-nice to have `git status` **not** warn me about these two files generated by autotools.