### PR TITLE
fix typo

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -77,7 +77,7 @@ typedef struct http_parser_settings http_parser_settings;
  * chunked' headers that indicate the presence of a body.
  *
  * Returning `2` from on_headers_complete will tell parser that it should not
- * expect neither a body nor any futher responses on this connection. This is
+ * expect neither a body nor any further responses on this connection. This is
  * useful for handling responses to a CONNECT request which may not contain
  * `Upgrade` or `Connection: upgrade` headers.
  *


### PR DESCRIPTION
from 'futher' to 'further'

-----------------

I'm not a native English speaker, maybe there is a word 'futher', but I can't find it by Google.
If I'm Wrong, forget me

