### PR TITLE
Update license boilerplate.

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,8 +1,4 @@
-http_parser.c is based on src/http/ngx_http_parse.c from NGINX copyright
-Igor Sysoev.
-
-Additional changes are licensed under the same terms as NGINX and
-copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Copyright Joyent, Inc. and other Node contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/contrib/parsertrace.c
+++ b/contrib/parsertrace.c
@@ -1,7 +1,4 @@
-/* Based on src/http/ngx_http_parse.c from NGINX copyright Igor Sysoev
- *
- * Additional changes are licensed under the same terms as NGINX and
- * copyright Joyent, Inc. and other Node contributors. All rights reserved.
+/* Copyright Joyent, Inc. and other Node contributors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/http_parser.c
+++ b/http_parser.c
@@ -1,7 +1,4 @@
-/* Based on src/http/ngx_http_parse.c from NGINX copyright Igor Sysoev
- *
- * Additional changes are licensed under the same terms as NGINX and
- * copyright Joyent, Inc. and other Node contributors. All rights reserved.
+/* Copyright Joyent, Inc. and other Node contributors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
The boilerplate included attribution to NGINX that created confusion
because NGINX is distributed under a different license (BSD, not MIT.)

To the best of everyone's knowledge, no actual NGINX code remains.
Remove the attribution to clear up the confusion.

Refs: https://github.com/nodejs/http-parser/issues/389