### PR TITLE
Makefile: Relative symlink paths, fixed DESTDIR, and cleaned up uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,19 +133,20 @@ tags: http_parser.c http_parser.h test.c
 install: library
 	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
 
 install-strip: library
 	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
 
 uninstall:
 	rm $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+	rm $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
 	rm $(DESTDIR)$(LIBDIR)/$(SONAME)
-	rm $(LIBDIR)/libhttp_parser.so
+	rm $(DESTDIR)$(LIBDIR)/$(LIBNAME)
 
 clean:
 	rm -f *.o *.a tags test test_fast test_g \

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ CFLAGS_LIB = $(CFLAGS_FAST) -fPIC
 LDFLAGS_LIB = $(LDFLAGS) -shared
 
 INSTALL ?= install
-PREFIX ?= $(DESTDIR)/usr/local
+PREFIX ?= /usr/local
 LIBDIR = $(PREFIX)/lib
 INCLUDEDIR = $(PREFIX)/include
 
@@ -131,20 +131,20 @@ tags: http_parser.c http_parser.h test.c
 	ctags $^
 
 install: library
-	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) -D $(LIBNAME) $(LIBDIR)/$(LIBNAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+	$(INSTALL) -D $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
+	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
 
 install-strip: library
-	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) -D -s $(LIBNAME) $(LIBDIR)/$(LIBNAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(LIBNAME) $(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+	$(INSTALL) -D -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
+	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -s $(LIBDIR)/$(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
 
 uninstall:
-	rm $(INCLUDEDIR)/http_parser.h
-	rm $(LIBDIR)/$(SONAME)
+	rm $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+	rm $(DESTDIR)$(LIBDIR)/$(SONAME)
 	rm $(LIBDIR)/libhttp_parser.so
 
 clean:


### PR DESCRIPTION
This pull request fixes a few issues relating to DESTDIR (Such as allowing you to specify DESTDIR and PREFIX at the same time without overriding eachother), as well as making the symbolic links not use full paths.

It also fixes two issues in uninstall: First, while install used $(LIBNAME), uninstall hard coded libhttp_parser.so. Uninstall also didn't remove all the files: It left a symlink dangling to a file that doesn't exist.