### PR TITLE
doc: try and standardize on project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ if (parser->upgrade) {
 }
 ```
 
-HTTP needs to know where the end of the stream is. For example, sometimes
+`http_parser` needs to know where the end of the stream is. For example, sometimes
 servers send responses without Content-Length and expect the client to
-consume input (for the body) until EOF. To tell http_parser about EOF, give
+consume input (for the body) until EOF. To tell `http_parser` about EOF, give
 `0` as the fourth parameter to `http_parser_execute()`. Callbacks and errors
 can still be encountered during an EOF, so one must still be prepared
 to receive them.
@@ -93,7 +93,7 @@ the on_body callback.
 The Special Problem of Upgrade
 ------------------------------
 
-HTTP supports upgrading the connection to a different protocol. An
+`http_parser` supports upgrading the connection to a different protocol. An
 increasingly common example of this is the WebSocket protocol which sends
 a request like
 
@@ -144,7 +144,7 @@ parse a request, and then give a response over that socket. By instantiation
 of a thread-local struct containing relevant data (e.g. accepted socket,
 allocated memory for callbacks to write into, etc), a parser's callbacks are
 able to communicate data between the scope of the thread and the scope of the
-callback in a threadsafe manner. This allows http-parser to be used in
+callback in a threadsafe manner. This allows `http_parser` to be used in
 multi-threaded contexts.
 
 Example:
@@ -202,7 +202,7 @@ void http_parser_thread(socket_t sock) {
 
 In case you parse HTTP message in chunks (i.e. `read()` request line
 from socket, parse, read half headers, parse, etc) your data callbacks
-may be called more than once. Http-parser guarantees that data pointer is only
+may be called more than once. `http_parser` guarantees that data pointer is only
 valid for the lifetime of callback. You can also `read()` into a heap allocated
 buffer to avoid copying memory around if this fits your application.
 


### PR DESCRIPTION
I went with `http_parser`, but if there's something better, happy to
change it to that.