### PR TITLE
Assign LIBDIR if not already defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ LDFLAGS_LIB = $(LDFLAGS) -shared
 
 INSTALL ?= install
 PREFIX ?= /usr/local
-LIBDIR = $(PREFIX)/lib
+LIBDIR ?= $(PREFIX)/lib
 INCLUDEDIR = $(PREFIX)/include
 
 ifeq (darwin,$(PLATFORM))


### PR DESCRIPTION
This makes it easier for packagers of multiarch-enabled systems.