### PR TITLE
return nonzero on parsing empty url

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2303,6 +2303,10 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
   enum http_parser_url_fields uf, old_uf;
   int found_at = 0;
 
+  if (buf == NULL || buf[0] == '\0') {
+    return 1;
+  }
+
   u->port = u->field_set = 0;
   s = is_connect ? s_req_server_start : s_req_spaces_before_url;
   old_uf = UF_MAX;

--- a/test.c
+++ b/test.c
@@ -3264,6 +3264,18 @@ const struct url_test url_tests[] =
   ,.rv=1 /* s_dead */
   }
 
+  , {.name="empty url"
+    ,.url=""
+    ,.is_connect=0
+    ,.rv=1
+    }
+
+  , {.name="NULL url"
+    ,.url=NULL
+    ,.is_connect=0
+    ,.rv=1
+    }
+
 #if HTTP_PARSER_STRICT
 
 , {.name="tab in URL"
@@ -3348,7 +3360,7 @@ test_parse_url (void)
     memset(&u, 0, sizeof(u));
 
     rv = http_parser_parse_url(test->url,
-                               strlen(test->url),
+                               test->url ? strlen(test->url) : 0,
                                test->is_connect,
                                &u);
 


### PR DESCRIPTION
Fixes #414 by returning `1` when the url is empty or `NULL`