### PR TITLE
http_status_str function

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2095,6 +2095,16 @@ http_method_str (enum http_method m)
   return ELEM_AT(method_strings, m, "<unknown>");
 }
 
+const char *
+http_status_str( enum http_status s )
+{
+  switch (s) {
+#define XX(num, name, string) case HTTP_STATUS_##name: return #string;
+    HTTP_STATUS_MAP( XX )
+#undef XX
+    default: return "<unknown>";
+  }
+}
 
 void
 http_parser_init (http_parser *parser, enum http_parser_type t)

--- a/http_parser.h
+++ b/http_parser.h
@@ -407,6 +407,9 @@ int http_should_keep_alive(const http_parser *parser);
 /* Returns a string version of the HTTP method. */
 const char *http_method_str(enum http_method m);
 
+/* Returns a string version of the HTTP status code. */
+const char *http_status_str(enum http_status s);
+
 /* Return a string name of the given error */
 const char *http_errno_name(enum http_errno err);
 

--- a/test.c
+++ b/test.c
@@ -3389,6 +3389,14 @@ test_method_str (void)
 }
 
 void
+test_status_str( void )
+{
+  assert(0 == strcmp("OK", http_status_str(HTTP_STATUS_OK)));
+  assert(0 == strcmp("Not Found", http_status_str(HTTP_STATUS_NOT_FOUND)));
+  assert(0 == strcmp("<unknown>", http_status_str(1337)));
+}
+
+void
 test_message (const struct message *message)
 {
   size_t raw_len = strlen(message->raw);
@@ -4117,6 +4125,7 @@ main (void)
   test_preserve_data();
   test_parse_url();
   test_method_str();
+  test_status_str();
 
   //// NREAD
   test_header_nread_value();


### PR DESCRIPTION
http_status_str function to get the string version of a HTTP status code

see ticket #371 