### PR TITLE
MSVC Error C2220: p hides prev. local declaration

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2407,7 +2407,6 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
   if (u->field_set & (1 << UF_PORT)) {
     uint16_t off;
     uint16_t len;
-    const char* p;
     const char* end;
     unsigned long v;
 


### PR DESCRIPTION
MSVC build output (with `/W4` and `TreatWarningsAsErrors=Yes`)
```
2>http_parser.c
2>c:\dev\...\http_parser\http_parser.c(2389,18): error C2220:  warning treated as error - no 'object' file generated
2>c:\dev\...\http_parser\http_parser.c(2389,18): error C2220:     const char* p;
2>c:\dev\...\http_parser\http_parser.c(2389,18): error C2220:                  ^
2>c:\dev\...\http_parser\http_parser.c(2389,18): warning C4456:  declaration of 'p' hides previous local declaration
2>c:\dev\...\http_parser\http_parser.c(2389,18): warning C4456:     const char* p;
2>c:\dev\...\http_parser\http_parser.c(2389,18): warning C4456:                  ^
2>c:\dev\...\http_parser\http_parser.c(2302,15): message :  see declaration of 'p'
2>c:\dev\...\http_parser\http_parser.c(2302,15): message :   const char *p;
2>c:\dev\...\http_parser\http_parser.c(2302,15): message :      
```
_(Line numbers don't match with current master since I've noticed the build-error when using 2.8.1)_

To fix this build-error I removed `const char* p;`-declaration as it is already declared right at
```c
http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
                      struct http_parser_url *u)
{
  enum state s;
  const char *p; // <-----
```
Since the removed `const char* p` within the if-statement is first used in line 2420 `for (p= buf + off` where it gets immediately assigned a new value, the removal should be completely harmless.