### PR TITLE
Make HTTP_MAX_HEADER_SIZE configurable via gyp

### DIFF
--- a/http_parser.gyp
+++ b/http_parser.gyp
@@ -47,6 +47,10 @@
     ],
   },
 
+  'variables': {
+    'http_max_header_size%': '8192'
+  },
+
   'targets': [
     {
       'target_name': 'http_parser',
@@ -56,7 +60,7 @@
         'defines': [ 'HTTP_PARSER_STRICT=0' ],
         'include_dirs': [ '.' ],
       },
-      'defines': [ 'HTTP_PARSER_STRICT=0' ],
+      'defines': [ 'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)', 'HTTP_PARSER_STRICT=0' ],
       'sources': [ './http_parser.c', ],
       'conditions': [
         ['OS=="win"', {
@@ -79,7 +83,7 @@
         'defines': [ 'HTTP_PARSER_STRICT=1' ],
         'include_dirs': [ '.' ],
       },
-      'defines': [ 'HTTP_PARSER_STRICT=1' ],
+      'defines': [ 'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)', 'HTTP_PARSER_STRICT=1' ],
       'sources': [ './http_parser.c', ],
       'conditions': [
         ['OS=="win"', {

--- a/http_parser.gyp
+++ b/http_parser.gyp
@@ -60,7 +60,10 @@
         'defines': [ 'HTTP_PARSER_STRICT=0' ],
         'include_dirs': [ '.' ],
       },
-      'defines': [ 'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)', 'HTTP_PARSER_STRICT=0' ],
+      'defines': [
+        'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)',
+        'HTTP_PARSER_STRICT=0'
+      ],
       'sources': [ './http_parser.c', ],
       'conditions': [
         ['OS=="win"', {
@@ -83,7 +86,10 @@
         'defines': [ 'HTTP_PARSER_STRICT=1' ],
         'include_dirs': [ '.' ],
       },
-      'defines': [ 'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)', 'HTTP_PARSER_STRICT=1' ],
+      'defines': [
+        'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)',
+        'HTTP_PARSER_STRICT=1'
+      ],
       'sources': [ './http_parser.c', ],
       'conditions': [
         ['OS=="win"', {


### PR DESCRIPTION
Spin out from https://github.com/nodejs/node/pull/24716.

This also sets the default to 8KB when compiled via gyp.