### PR TITLE
Fix: Content-Length with obsolete line folding and invalid input

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1434,7 +1434,8 @@ reexecute:
             parser->header_state = h_content_length_num;
             break;
 
-          // when obsolete line folding is encountered for content length continue to the s_header_value state
+          /* when obsolete line folding is encountered for content length
+           * continue to the s_header_value state */
           case h_content_length_ws:
             break;
 
@@ -1682,7 +1683,7 @@ reexecute:
       {
         if (ch == ' ' || ch == '\t') {
           if (parser->header_state == h_content_length_num) {
-              // treat obsolete line folding as space
+              /* treat obsolete line folding as space */
               parser->header_state = h_content_length_ws;
           }
           UPDATE_STATE(s_header_value_start);

--- a/http_parser.c
+++ b/http_parser.c
@@ -1434,6 +1434,10 @@ reexecute:
             parser->header_state = h_content_length_num;
             break;
 
+          // when obsolete line folding is encountered for content length continue to the s_header_value state
+          case h_content_length_ws:
+            break;
+
           case h_connection:
             /* looking for 'Connection: keep-alive' */
             if (c == 'k') {
@@ -1677,6 +1681,10 @@ reexecute:
       case s_header_value_lws:
       {
         if (ch == ' ' || ch == '\t') {
+          if (parser->header_state == h_content_length_num) {
+              // treat obsolete line folding as space
+              parser->header_state = h_content_length_ws;
+          }
           UPDATE_STATE(s_header_value_start);
           REEXECUTE();
         }

--- a/test.c
+++ b/test.c
@@ -4203,6 +4203,20 @@ main (void)
       HPE_INVALID_CONTENT_LENGTH,
       HTTP_REQUEST);
 
+  test_simple_type(
+      "POST / HTTP/1.1\r\n"
+      "Content-Length:  42\r\n"
+      " Hello world!\r\n",
+      HPE_INVALID_CONTENT_LENGTH,
+      HTTP_REQUEST);
+
+  test_simple_type(
+      "POST / HTTP/1.1\r\n"
+      "Content-Length:  42\r\n"
+      " \r\n",
+      HPE_OK,
+      HTTP_REQUEST);
+
   //// RESPONSES
 
   test_simple_type("HTP/1.1 200 OK\r\n\r\n", HPE_INVALID_VERSION, HTTP_RESPONSE);


### PR DESCRIPTION
Fix for the issue: https://github.com/nodejs/http-parser/issues/456

- treat obsolete line folding as space and continue parsing
- update tests