### PR TITLE
Fix type conversion warnings in Visual Studio 2017 64-bit

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -153,7 +153,7 @@ do {                                                                 \
  */
 #define COUNT_HEADER_SIZE(V)                                         \
 do {                                                                 \
-  nread += (V);                                                      \
+  nread += (uint32_t)(V);                                            \
   if (UNLIKELY(nread > max_header_size)) {                           \
     SET_ERRNO(HPE_HEADER_OVERFLOW);                                  \
     goto error;                                                      \
@@ -2281,14 +2281,14 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
     switch(new_s) {
       case s_http_host:
         if (s != s_http_host) {
-          u->field_data[UF_HOST].off = p - buf;
+          u->field_data[UF_HOST].off = (uint16_t)(p - buf);
         }
         u->field_data[UF_HOST].len++;
         break;
 
       case s_http_host_v6:
         if (s != s_http_host_v6) {
-          u->field_data[UF_HOST].off = p - buf;
+          u->field_data[UF_HOST].off = (uint16_t)(p - buf);
         }
         u->field_data[UF_HOST].len++;
         break;
@@ -2300,7 +2300,7 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
 
       case s_http_host_port:
         if (s != s_http_host_port) {
-          u->field_data[UF_PORT].off = p - buf;
+          u->field_data[UF_PORT].off = (uint16_t)(p - buf);
           u->field_data[UF_PORT].len = 0;
           u->field_set |= (1 << UF_PORT);
         }
@@ -2309,7 +2309,7 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
 
       case s_http_userinfo:
         if (s != s_http_userinfo) {
-          u->field_data[UF_USERINFO].off = p - buf ;
+          u->field_data[UF_USERINFO].off = (uint16_t)(p - buf);
           u->field_data[UF_USERINFO].len = 0;
           u->field_set |= (1 << UF_USERINFO);
         }
@@ -2413,7 +2413,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       continue;
     }
 
-    u->field_data[uf].off = p - buf;
+    u->field_data[uf].off = (uint16_t)(p - buf);
     u->field_data[uf].len = 1;
 
     u->field_set |= (1 << uf);


### PR DESCRIPTION
This PR fixes a bunch of warnings in Visual Studio 64-bit builds:

* Conversion from `__int64` to `int32_t` in `COUNT_HEADER_SIZE`
* Conversion from `__int64` to `int16_t` when assigning the difference of 2 pointers to the `off` field

```
http_parser.c(1368): warning C4244: '+=': conversion from '__int64' to 'uint32_t', possible loss of data
http_parser.c(1372): warning C4244: '+=': conversion from '__int64' to 'uint32_t', possible loss of data
http_parser.c(1484): warning C4244: '+=': conversion from '__int64' to 'uint32_t', possible loss of data
http_parser.c(1669): warning C4244: '+=': conversion from '__int64' to 'uint32_t', possible loss of data
http_parser.c(2284): warning C4244: '=': conversion from '__int64' to 'uint16_t', possible loss of data
http_parser.c(2291): warning C4244: '=': conversion from '__int64' to 'uint16_t', possible loss of data
http_parser.c(2303): warning C4244: '=': conversion from '__int64' to 'uint16_t', possible loss of data
http_parser.c(2312): warning C4244: '=': conversion from '__int64' to 'uint16_t', possible loss of data
http_parser.c(2416): warning C4244: '=': conversion from '__int64' to 'uint16_t', possible loss of data
```

(as of commit 350258965909f249f9c59823aac240313e0d0120)