### PR TITLE
Always skip body for 1xx, 204, and 304 responses

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -886,10 +886,11 @@ reexecute:
       case s_res_status_start:
       {
         /* See RFC 7230 section 3.3.3, step 1 */
-        if (parser->status_code / 100 == 1 || /* 1xx e.g. Continue */
+        if ((parser->status_code >= 100 &&
+             parser->status_code < 200) ||    /* 1xx e.g. Continue */
             parser->status_code == 204 ||     /* No Content */
             parser->status_code == 304) {     /* Not Modified */
-            parser->flags |= F_SKIPBODY;
+          parser->flags |= F_SKIPBODY;
         }
         MARK(status);
         UPDATE_STATE(s_res_status);

--- a/test.c
+++ b/test.c
@@ -1848,8 +1848,7 @@ const struct message responses[] =
   ,.http_minor= 1
   ,.status_code= 101
   ,.response_status= "Switching Protocols"
-  ,.body= "body"
-  ,.upgrade= "proto"
+  ,.upgrade= "bodyproto"
   ,.num_headers= 3
   ,.headers=
     { { "Connection", "upgrade" }
@@ -1879,16 +1878,13 @@ const struct message responses[] =
   ,.http_minor= 1
   ,.status_code= 101
   ,.response_status= "Switching Protocols"
-  ,.body= "body"
-  ,.upgrade= "proto"
+  ,.upgrade= "2\r\nbo\r\n2\r\ndy\r\n0\r\n\r\nproto"
   ,.num_headers= 3
   ,.headers=
     { { "Connection", "upgrade" }
     , { "Upgrade", "h2c" }
     , { "Transfer-Encoding", "chunked" }
     }
-  ,.num_chunks_complete= 3
-  ,.chunk_lengths= { 2, 2 }
   }
 
 #define HTTP_200_RESPONSE_WITH_UPGRADE_HEADER 25


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7230#section-3.3.3:
... any response with a 1xx (Informational), 204 (No Content), or 304 (Not Modified) status code is always terminated by the first empty line after the header fields, regardless of the header fields present in the message, and thus cannot contain a message body.

Fixes: https://github.com/nodejs/http-parser/issues/251