### PR TITLE
Fix -Wsign-compare warning

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1497,9 +1497,10 @@ reexecute:
           switch (h_state) {
             case h_general:
               {
-                const char* limit = p + MIN(data + len - p, max_header_size);
+                size_t left = data + len - p;
+                const char* pe = p + MIN(left, max_header_size);
 
-                for (; p != limit; p++) {
+                for (; p != pe; p++) {
                   ch = *p;
                   if (ch == CR || ch == LF) {
                     --p;


### PR DESCRIPTION
Commit 2a0d106 ("http_parser: revert `memchr()` optimization")
introduced a -Wsign-compare warning that manifests itself with
gcc 7.4.0 but not older versions.

The type of p - q is signed when p and q are pointers and was
compared against an unsigned type. Its actual value is always >= 0
however and can be safely cast to size_t.

Fixes: https://github.com/nodejs/http-parser/issues/471