### PR TITLE
Fix bad pointer arithmetic

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1257,9 +1257,9 @@ reexecute:
 
           switch (parser->header_state) {
             case h_general: {
-              size_t limit = data + len - p;
-              limit = MIN(limit, max_header_size);
-              while (p+1 < data + limit && TOKEN(p[1])) {
+              size_t left = data + len - p;
+              const char* pe = p + MIN(left, max_header_size);
+              while (p+1 < pe && TOKEN(p[1])) {
                 p++;
               }
               break;


### PR DESCRIPTION
The bad arithmetic didn't result in wrong or insecure behavior
(there were no out-of-bound accesses and forward progress was
still being made because of the outer loop) but it did regress
the performance of header field parsing rather massively.

Taking the test suite as an example: the inner fast path loop
was skipped over 4.4 million times, falling back to the outer
slow path loop. After this commit that only happens about
2,000 times - a 2,200-fold reduction.

Fixes: https://github.com/nodejs/http-parser/issues/473