### PR TITLE
Fix http_parser_parse_url to handle very long URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ PLATFORM ?= $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
 HELPER ?=
 BINEXT ?=
 SOLIBNAME = libhttp_parser
-SOMAJOR = 2
-SOMINOR = 9
-SOREV   = 2
+SOMAJOR = 3
+SOMINOR = 0
+SOREV   = 0
 ifeq (darwin,$(PLATFORM))
 SOEXT ?= dylib
 SONAME ?= $(SOLIBNAME).$(SOMAJOR).$(SOMINOR).$(SOEXT)

--- a/http_parser.c
+++ b/http_parser.c
@@ -2278,14 +2278,14 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
     switch(new_s) {
       case s_http_host:
         if (s != s_http_host) {
-          u->field_data[UF_HOST].off = (uint16_t)(p - buf);
+          u->field_data[UF_HOST].off = (size_t)(p - buf);
         }
         u->field_data[UF_HOST].len++;
         break;
 
       case s_http_host_v6:
         if (s != s_http_host_v6) {
-          u->field_data[UF_HOST].off = (uint16_t)(p - buf);
+          u->field_data[UF_HOST].off = (size_t)(p - buf);
         }
         u->field_data[UF_HOST].len++;
         break;
@@ -2297,7 +2297,7 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
 
       case s_http_host_port:
         if (s != s_http_host_port) {
-          u->field_data[UF_PORT].off = (uint16_t)(p - buf);
+          u->field_data[UF_PORT].off = (size_t)(p - buf);
           u->field_data[UF_PORT].len = 0;
           u->field_set |= (1 << UF_PORT);
         }
@@ -2306,7 +2306,7 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
 
       case s_http_userinfo:
         if (s != s_http_userinfo) {
-          u->field_data[UF_USERINFO].off = (uint16_t)(p - buf);
+          u->field_data[UF_USERINFO].off = (size_t)(p - buf);
           u->field_data[UF_USERINFO].len = 0;
           u->field_set |= (1 << UF_USERINFO);
         }
@@ -2410,7 +2410,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       continue;
     }
 
-    u->field_data[uf].off = (uint16_t)(p - buf);
+    u->field_data[uf].off = (size_t)(p - buf);
     u->field_data[uf].len = 1;
 
     u->field_set |= (1 << uf);
@@ -2436,8 +2436,8 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
   }
 
   if (u->field_set & (1 << UF_PORT)) {
-    uint16_t off;
-    uint16_t len;
+    size_t off;
+    size_t len;
     const char* p;
     const char* end;
     unsigned long v;

--- a/http_parser.h
+++ b/http_parser.h
@@ -25,9 +25,9 @@ extern "C" {
 #endif
 
 /* Also update SONAME in the Makefile whenever you change these. */
-#define HTTP_PARSER_VERSION_MAJOR 2
-#define HTTP_PARSER_VERSION_MINOR 9
-#define HTTP_PARSER_VERSION_PATCH 2
+#define HTTP_PARSER_VERSION_MAJOR 3
+#define HTTP_PARSER_VERSION_MINOR 0
+#define HTTP_PARSER_VERSION_PATCH 0
 
 #include <stddef.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && \
@@ -362,8 +362,8 @@ struct http_parser_url {
   uint16_t port;                /* Converted UF_PORT string */
 
   struct {
-    uint16_t off;               /* Offset into buffer in which field starts */
-    uint16_t len;               /* Length of run in buffer */
+    size_t off;                 /* Offset into buffer in which field starts */
+    size_t len;                 /* Length of run in buffer */
   } field_data[UF_MAX];
 };
 


### PR DESCRIPTION
Earlier http_parser_parse_url would incorrectly parse very long URLs: The resulting off and len parameters would just get truncated. Even though very long URLs are typically considered invalid by servers they could still end up being parsed by http_parser_parse_url. Thus it's better handle this situation gracefully.

This change is unfortunately not backwards ABI compatible due to changes in http_parser_url structure field types, hence the major version number bump.