### PR TITLE
Use -f option when calling ln at install time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,14 +133,14 @@ tags: http_parser.c http_parser.h test.c
 install: library
 	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
-	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
-	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
 
 install-strip: library
 	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
-	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
-	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
 
 uninstall:
 	rm $(DESTDIR)$(INCLUDEDIR)/http_parser.h


### PR DESCRIPTION
This allows "make install; make install" to work properly.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
Signed-off-by: Renaud AUBIN <root@renaud.io>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libhttpparser/0001-Use-f-option-when-calling-ln-at-install-time.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>