### PR TITLE
Update http_parser.content_length doc comment.

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -306,7 +306,9 @@ struct http_parser {
   unsigned int lenient_http_headers : 1;
 
   uint32_t nread;          /* # bytes read in various scenarios */
-  uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
+  uint64_t content_length; /* # bytes in body. `(uint64_t) -1` (all bits one)
+                            * if no Content-Length header.
+                            */
 
   /** READ-ONLY **/
   unsigned short http_major;


### PR DESCRIPTION
It's -1 when no Content-Length field is present, not 0.

Fixes: https://github.com/nodejs/http-parser/issues/512