### PR TITLE
Fix -Wsign-compare warning.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2517,7 +2517,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
     end = buf + off + len;
 
     /* NOTE: The characters are already validated and are in the [0-9] range */
-    assert(off + len <= buflen && "Port number overflow");
+    assert((size_t) (off + len) <= buflen && "Port number overflow");
     v = 0;
     for (p = buf + off; p < end; p++) {
       v *= 10;


### PR DESCRIPTION
The operands to `+` are promoted from `uint16_t` to `int` before
addition, making the expression `off + len <= buflen` emit a
warning because `buflen` is unsigned.

Fixes: https://github.com/nodejs/http-parser/issues/514