### PR TITLE
docs: fix simple typo, recieving -> receiving

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1839,7 +1839,7 @@ reexecute:
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we
          * will interpret that as saying that this message has no body. This
-         * is needed for the annoying case of recieving a response to a HEAD
+         * is needed for the annoying case of receiving a response to a HEAD
          * request.
          *
          * We'd like to use CALLBACK_NOTIFY_NOADVANCE() here but we cannot, so


### PR DESCRIPTION
There is a small typo in http_parser.c.

Should read `receiving` rather than `recieving`.

