### PR TITLE
Fix sizeof(http_parser) assert on i386

### DIFF
--- a/test.c
+++ b/test.c
@@ -4348,7 +4348,7 @@ main (void)
   /* Should be 32 on both 32 bits and 64 bits x86 because of struct padding,
    * see https://github.com/nodejs/http-parser/issues/507.
    */
-  assert(sizeof(http_parser) == 32);
+  assert(sizeof(http_parser) == 24 + sizeof(void*));
 #endif
 
   //// API


### PR DESCRIPTION
The struct size is actually 28 bytes because the void* field is 4 bytes
shorter.  As the people on the original bug explained, x86 has lower
alignment requirements than other arches, so the struct is not padded.
However, this does not mean you can ignore the void* size difference.