### PR TITLE
http: unset `F_CHUNKED` on new `Transfer-Encoding` (Fixes CVE-2020-8287)

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1344,6 +1344,13 @@ reexecute:
               } else if (parser->index == sizeof(TRANSFER_ENCODING)-2) {
                 parser->header_state = h_transfer_encoding;
                 parser->uses_transfer_encoding = 1;
+
+                /* Multiple `Transfer-Encoding` headers should be treated as
+                 * one, but with values separate by a comma.
+                 *
+                 * See: https://tools.ietf.org/html/rfc7230#section-3.2.2
+                 */
+                parser->flags &= ~F_CHUNKED;
               }
               break;
 

--- a/test.c
+++ b/test.c
@@ -2154,6 +2154,32 @@ const struct message responses[] =
   ,.body= "2\r\nOK\r\n0\r\n\r\n"
   ,.num_chunks_complete= 0
   }
+#define HTTP_200_DUPLICATE_TE_NOT_LAST_CHUNKED 30
+, {.name= "HTTP 200 response with `chunked` and duplicate Transfer-Encoding"
+  ,.type= HTTP_RESPONSE
+  ,.raw= "HTTP/1.1 200 OK\r\n"
+         "Transfer-Encoding: chunked\r\n"
+         "Transfer-Encoding: identity\r\n"
+         "\r\n"
+         "2\r\n"
+         "OK\r\n"
+         "0\r\n"
+         "\r\n"
+  ,.should_keep_alive= FALSE
+  ,.message_complete_on_eof= TRUE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.status_code= 200
+  ,.response_status= "OK"
+  ,.content_length= -1
+  ,.num_headers= 2
+  ,.headers=
+    { { "Transfer-Encoding", "chunked" }
+    , { "Transfer-Encoding", "identity" }
+    }
+  ,.body= "2\r\nOK\r\n0\r\n\r\n"
+  ,.num_chunks_complete= 0
+  }
 };
 
 /* strnlen() is a POSIX.2008 addition. Can't rely on it being available so


### PR DESCRIPTION
This change has only been integrated with the bundled version of `http-parser` in the node sources;

https://github.com/nodejs/node/commit/fc70ce08f5818a286fb5899a1bc3aff5965a745e

Can it please be synced here, with a release being made as well? 