### PR TITLE
Fix gcc comma at end of enumerator list warning.

### DIFF
--- a/http_parser.h
+++ b/http_parser.h
@@ -158,6 +158,7 @@ enum http_status
 #define XX(num, name, string) HTTP_STATUS_##name = num,
   HTTP_STATUS_MAP(XX)
 #undef XX
+  HTTP_STATUS_LAST = HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED
   };
 
 
@@ -211,6 +212,7 @@ enum http_method
 #define XX(num, name, string) HTTP_##name = num,
   HTTP_METHOD_MAP(XX)
 #undef XX
+  HTTP_LAST = HTTP_SOURCE
   };
 
 
@@ -286,6 +288,7 @@ enum flags
 #define HTTP_ERRNO_GEN(n, s) HPE_##n,
 enum http_errno {
   HTTP_ERRNO_MAP(HTTP_ERRNO_GEN)
+  HPE_LAST = HPE_INVALID_TRANSFER_ENCODING
 };
 #undef HTTP_ERRNO_GEN
 


### PR DESCRIPTION
Add dummy "LAST" items to each enum to mask the gcc "comma at end of enumerator list" warning and allow building with -Werror.